### PR TITLE
fix(sql): resolve foreign key constraing when deleting links with analytics data

### DIFF
--- a/scripts/clear-test-db.sh
+++ b/scripts/clear-test-db.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-# Clear the local D1 database for fresh integration tests
+# Clear the local D1 database and KV namespace for fresh integration tests
 # This removes all data to simulate a fresh instance
 
 set -e
 
-echo "🧹 Clearing local D1 database..."
+echo "🧹 Clearing local D1 database and KV namespace..."
 
-# Drop and recreate the local database
-echo "Dropping local database..."
-wrangler d1 execute rushomon --local --command "DROP TABLE IF EXISTS users; DROP TABLE IF EXISTS organizations; DROP TABLE IF EXISTS links; DROP TABLE IF EXISTS analytics_events;" 2>/dev/null || true
+# Clear local miniflare state (both D1 and KV)
+# This is the fastest approach — wrangler dev uses .wrangler/state/v3/ for local storage
+echo "Clearing local KV state (rate limits, sessions, link mappings)..."
+rm -rf .wrangler/state/v3/kv/miniflare-KVNamespaceObject/ 2>/dev/null || true
 
-# Clear migration state and re-run migrations
-echo "Clearing migration state..."
+echo "Clearing local D1 state..."
 rm -rf .wrangler/state/v3/d1/miniflare-D1DatabaseObject/ 2>/dev/null || true
 
 echo "Reapplying migrations..."
-wrangler d1 migrations apply rushomon --local
+yes | wrangler d1 migrations apply rushomon --local
 
-echo "✅ Local D1 database cleared"
+echo "✅ Local D1 database and KV namespace cleared"
 echo ""
 echo "Now run: ./scripts/run-integration-tests.sh"
 echo "The first user created will be assigned admin role."


### PR DESCRIPTION
Fixes #28 

- Delete analytics_events before deleting the link in hard_delete_link()
- Add integration test to verify deletion works with analytics data
- Update clear-test-db.sh to clear both D1 and KV miniflare state