### PR TITLE
Fix org deletion and hardcoded localhost URLs

### DIFF
--- a/frontend/src/lib/api/orgs.ts
+++ b/frontend/src/lib/api/orgs.ts
@@ -5,6 +5,7 @@ import type {
 	OrgWithRole,
 	OrgInvitation,
 	InviteInfo,
+	UsageResponse,
 } from '$lib/types/api';
 
 export const orgsApi = {
@@ -67,5 +68,9 @@ export const orgsApi = {
 			`/api/orgs/${org_id}`,
 			{ action, target_org_id },
 		);
+	},
+
+	async getUsage(): Promise<UsageResponse> {
+		return apiClient.get<UsageResponse>('/api/usage');
 	},
 };

--- a/frontend/src/routes/dashboard/org/+page.svelte
+++ b/frontend/src/routes/dashboard/org/+page.svelte
@@ -201,13 +201,8 @@
 			canDelete = ownedOrgs.length > 1;
 
 			// Get link count from usage API
-			const usageRes = await fetch("http://localhost:8787/api/usage", {
-				credentials: "include",
-			});
-			if (usageRes.ok) {
-				const usage = await usageRes.json();
-				linkCount = usage.links_created_this_month || 0;
-			}
+			const usage = await orgsApi.getUsage();
+			linkCount = usage.usage?.links_created_this_month || 0;
 		} catch (e) {
 			canDelete = false;
 		}


### PR DESCRIPTION
- Remove broken DELETE from monthly_counters (now at billing account level)
- Remove deprecated monthly counter functions using old org_id column
- Replace hardcoded localhost:8787 with apiClient in org page
- Add getUsage() method to orgsApi for proper environment variable usage

Closes #102 