### PR TITLE
feat(oauth): improve handling of oauth and conflicts

### DIFF
--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -216,6 +216,18 @@ export const adminApi = {
 	},
 
 	/**
+	 * Delete a user (admin only)
+	 * @param id - User UUID
+	 * @returns Success message with deletion counts
+	 */
+	async deleteUser(id: string): Promise<{ success: boolean; message: string; deleted_user_count: number; deleted_links_count: number; deleted_analytics_count: number; }> {
+		return apiClient.request<{ success: boolean; message: string; deleted_user_count: number; deleted_links_count: number; deleted_analytics_count: number; }>(`/api/admin/users/${id}`, {
+			method: 'DELETE',
+			body: JSON.stringify({ confirmation: 'DELETE' })
+		});
+	},
+
+	/**
 	 * Submit an abuse report for a link (public endpoint, can be called by anyone)
 	 * @param linkId - Link UUID or short code
 	 * @param reason - Reason for the report

--- a/frontend/src/routes/admin/users/+page.svelte
+++ b/frontend/src/routes/admin/users/+page.svelte
@@ -21,6 +21,7 @@
 	let orgTiers = $state<Record<string, string>>({});
 	let activeDropdown = $state<string | null>(null);
 	let confirmingSuspend = $state<string | null>(null);
+	let confirmingDelete = $state<string | null>(null);
 	let dropdownPosition = $state<{ top: number; right: number } | null>(null);
 	let selectedNewTier = $state<string>("");
 
@@ -181,6 +182,30 @@
 		} finally {
 			loading = false;
 		}
+	}
+
+	async function handleDelete(userId: string) {
+		confirmingDelete = userId;
+	}
+
+	async function confirmDelete() {
+		if (!confirmingDelete) return;
+
+		try {
+			loading = true;
+			await adminApi.deleteUser(String(confirmingDelete));
+			await loadUsers(); // Reload to show updated user list
+		} catch (err) {
+			error = "Failed to delete user";
+			console.error(err);
+		} finally {
+			loading = false;
+			confirmingDelete = null;
+		}
+	}
+
+	function cancelDelete() {
+		confirmingDelete = null;
 	}
 
 	function getOrgTier(orgId: string): string {
@@ -404,6 +429,17 @@
 															Suspend User
 														</button>
 													{/if}
+													<button
+														class="dropdown-item delete"
+														onclick={() => {
+															handleDelete(
+																user.id,
+															);
+															closeDropdown();
+														}}
+													>
+														Delete User
+													</button>
 												</div>
 											{/if}
 										</div>
@@ -665,6 +701,70 @@
 						Suspending...
 					{:else}
 						Suspend User
+					{/if}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Delete Confirmation Modal -->
+{#if confirmingDelete}
+	<div
+		class="modal-backdrop"
+		role="button"
+		tabindex="0"
+		onclick={cancelDelete}
+		onkeydown={(e) => e.key === "Enter" && cancelDelete()}
+	>
+		<div
+			class="modal"
+			onclick={(e) => e.stopPropagation()}
+			role="dialog"
+			aria-modal="true"
+			tabindex="0"
+			onkeydown={(e) => e.key === "Escape" && cancelDelete()}
+		>
+			<div class="modal-header">
+				<h3>Delete User?</h3>
+				<button class="modal-close" onclick={cancelDelete}
+					>&times;</button
+				>
+			</div>
+			<div class="modal-body">
+				<p>
+					Are you sure you want to <strong
+						>permanently delete this user</strong
+					>?
+				</p>
+				<p class="warning">
+					⚠️ This action cannot be undone. The following will be
+					permanently deleted:
+				</p>
+				<ul class="deletion-list">
+					<li>User account and profile information</li>
+					<li>All links created by this user</li>
+					<li>All analytics data for their links</li>
+					<li>Organization membership</li>
+				</ul>
+			</div>
+			<div class="modal-footer">
+				<button
+					class="btn btn-secondary"
+					onclick={cancelDelete}
+					disabled={loading}
+				>
+					Cancel
+				</button>
+				<button
+					class="btn btn-danger"
+					onclick={confirmDelete}
+					disabled={loading}
+				>
+					{#if loading}
+						Deleting...
+					{:else}
+						Delete Permanently
 					{/if}
 				</button>
 			</div>
@@ -998,8 +1098,30 @@
 		color: #d97706;
 	}
 
+	.dropdown-item.delete {
+		color: #dc2626;
+		border-top: 1px solid #e5e7eb;
+	}
+
 	.dropdown-item.success {
 		color: #059669;
+	}
+
+	/* Delete modal specific styles */
+	.warning {
+		color: #dc2626;
+		font-weight: 600;
+		margin: 1rem 0;
+	}
+
+	.deletion-list {
+		margin: 1rem 0;
+		padding-left: 1.5rem;
+		color: #6b7280;
+	}
+
+	.deletion-list li {
+		margin-bottom: 0.5rem;
 	}
 
 	.dropdown-overlay {

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -13,6 +13,10 @@
 		$page.url.searchParams.get("error") === "signups_disabled",
 	);
 
+	let emailAlreadyUsed = $derived(
+		$page.url.searchParams.get("error") === "email_already_used",
+	);
+
 	onMount(async () => {
 		try {
 			providers = await authApi.getProviders();
@@ -67,6 +71,22 @@
 					</p>
 					<p class="mt-1 text-red-600">
 						Contact the administrator if you need access.
+					</p>
+				</div>
+			{/if}
+
+			<!-- Email Already Used Error -->
+			{#if emailAlreadyUsed}
+				<div
+					class="bg-yellow-50 border border-yellow-200 text-yellow-800 px-4 py-3 rounded-xl mb-6 text-sm"
+				>
+					<p class="font-medium">
+						Email already in use with different login method
+					</p>
+					<p class="mt-1 text-yellow-700">
+						This email is already associated with an account using a
+						different login method. Please use the same login method
+						you originally used to sign in.
 					</p>
 				</div>
 			{/if}

--- a/src/auth/github.rs
+++ b/src/auth/github.rs
@@ -1,6 +1,48 @@
 use crate::auth::providers::NormalizedUser;
 use serde::Deserialize;
-use worker::{Error, Fetch, Headers, Method, Request, RequestInit, Result};
+use worker::{Error, Fetch, Headers, Method, Request, RequestInit, Result, console_log};
+
+/// Check if an email is a GitHub noreply address
+pub fn is_noreply_email(email: &str) -> bool {
+    email.ends_with("@users.noreply.github.com")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_noreply_email_detects_github_noreply() {
+        assert!(is_noreply_email("user@users.noreply.github.com"));
+        assert!(is_noreply_email("piffio@users.noreply.github.com"));
+        assert!(is_noreply_email("test123@users.noreply.github.com"));
+
+        assert!(!is_noreply_email("user@gmail.com"));
+        assert!(!is_noreply_email("user@github.com"));
+        assert!(!is_noreply_email("user@users.noreply.github.com.org"));
+        assert!(!is_noreply_email("user@noreply.github.com"));
+    }
+
+    #[test]
+    fn test_is_noreply_email_edge_cases() {
+        // Empty string
+        assert!(!is_noreply_email(""));
+
+        // Partial matches
+        assert!(!is_noreply_email("prefix-users.noreply.github.com"));
+        assert!(!is_noreply_email("users.noreply.github.com-suffix"));
+
+        // Case sensitivity - ends_with is case-sensitive
+        assert!(!is_noreply_email("USER@USERS.NOREPLY.GITHUB.COM"));
+        assert!(is_noreply_email("user@users.noreply.github.com"));
+
+        // Exact matches with different usernames
+        assert!(is_noreply_email("a@users.noreply.github.com"));
+        assert!(is_noreply_email(
+            "very-long-username-123@users.noreply.github.com"
+        ));
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct GitHubUser {
@@ -9,6 +51,14 @@ pub struct GitHubUser {
     pub email: Option<String>,
     pub name: Option<String>,
     pub avatar_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GitHubEmail {
+    pub email: String,
+    pub verified: bool,
+    pub primary: bool,
+    pub visibility: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -60,6 +110,50 @@ pub async fn exchange_code_for_token(
     Ok(token_response.access_token)
 }
 
+/// Fetch user emails from GitHub API
+pub async fn fetch_user_emails(access_token: &str) -> Result<Vec<GitHubEmail>> {
+    let headers = Headers::new();
+    headers.set("Authorization", &format!("token {}", access_token))?;
+    headers.set("User-Agent", "Rushomon")?;
+    headers.set("Accept", "application/vnd.github.v3+json")?;
+
+    let mut init = RequestInit::new();
+    init.with_method(Method::Get).with_headers(headers);
+
+    let request = Request::new_with_init("https://api.github.com/user/emails", &init)?;
+    let mut response = Fetch::Request(request).send().await?;
+
+    if response.status_code() != 200 {
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(Error::RustError(format!(
+            "GitHub emails fetch failed: {}",
+            error_text
+        )));
+    }
+
+    let emails: Vec<GitHubEmail> = response.json().await?;
+    Ok(emails)
+}
+
+/// Find the primary verified email from a list of emails
+fn find_primary_email(emails: &[GitHubEmail]) -> Option<String> {
+    // First try to find a verified primary email
+    emails
+        .iter()
+        .find(|email| email.primary && email.verified)
+        .map(|email| email.email.clone())
+        .or_else(|| {
+            // If no primary email, fall back to any verified email
+            emails
+                .iter()
+                .find(|email| email.verified)
+                .map(|email| email.email.clone())
+        })
+}
+
 /// Fetch and normalize user profile from GitHub API
 pub async fn fetch_user(access_token: &str, user_url: &str) -> Result<NormalizedUser> {
     let headers = Headers::new();
@@ -86,12 +180,26 @@ pub async fn fetch_user(access_token: &str, user_url: &str) -> Result<Normalized
 
     let github_user: GitHubUser = response.json().await?;
 
+    // If email is not provided in the main user endpoint, fetch from emails endpoint
+    let email = if github_user.email.is_none() {
+        match fetch_user_emails(access_token).await {
+            Ok(emails) => find_primary_email(&emails),
+            Err(_) => {
+                // If fetching emails fails, log the error and fall back to noreply
+                console_log!(
+                    "Failed to fetch user emails from GitHub, falling back to noreply email"
+                );
+                None
+            }
+        }
+    } else {
+        github_user.email.clone()
+    };
+
     Ok(NormalizedUser {
         provider: "github".to_string(),
         provider_id: github_user.id.to_string(),
-        email: github_user
-            .email
-            .unwrap_or_else(|| format!("{}@users.noreply.github.com", github_user.login)),
+        email: email.unwrap_or_else(|| format!("{}@users.noreply.github.com", github_user.login)),
         name: Some(
             github_user
                 .name

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -332,9 +332,28 @@ async fn create_or_get_user(
         .await?;
 
     if let Some(user) = email_user {
-        // Link this provider to the existing account
+        // Check if this email is already associated with a different OAuth provider
+        if user.oauth_provider != normalized_user.provider {
+            return Err(Error::RustError(format!(
+                "EMAIL_ALREADY_USED:{}",
+                user.oauth_provider
+            )));
+        }
+
+        // Preserve existing real email if the new email is a noreply address
+        let email_to_use = if crate::auth::github::is_noreply_email(&normalized_user.email)
+            && !crate::auth::github::is_noreply_email(&user.email)
+        {
+            // Keep the existing real email
+            user.email.clone()
+        } else {
+            // Use the new email (real email or noreply for new users)
+            normalized_user.email
+        };
+
+        // Link this provider to the existing account (same provider, different ID)
         let create_data = CreateUserData {
-            email: normalized_user.email,
+            email: email_to_use,
             name: normalized_user.name,
             avatar_url: normalized_user.avatar_url,
             oauth_provider: normalized_user.provider,
@@ -395,6 +414,128 @@ async fn create_or_get_user(
         .await?;
 
     Ok((user, org))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::auth::providers::NormalizedUser;
+    use crate::models::User;
+
+    // Mock user for testing
+    fn create_mock_user(id: &str, email: &str, provider: &str) -> User {
+        User {
+            id: id.to_string(),
+            email: email.to_string(),
+            name: Some("Test User".to_string()),
+            avatar_url: Some("https://example.com/avatar.jpg".to_string()),
+            oauth_provider: provider.to_string(),
+            oauth_id: "12345".to_string(),
+            org_id: "org-123".to_string(),
+            role: "member".to_string(),
+            created_at: 1234567890,
+            suspended_at: None,
+            suspension_reason: None,
+            suspended_by: None,
+        }
+    }
+
+    fn create_mock_normalized_user(email: &str, provider: &str) -> NormalizedUser {
+        NormalizedUser {
+            email: email.to_string(),
+            name: Some("Test User".to_string()),
+            avatar_url: Some("https://example.com/avatar.jpg".to_string()),
+            provider: provider.to_string(),
+            provider_id: "12345".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_email_preservation_logic_real_email_preserved() {
+        // Test case: Existing user with real email, GitHub fetch fails (returns noreply)
+        let existing_user = create_mock_user("user-123", "real@gmail.com", "github");
+        let normalized_user =
+            create_mock_normalized_user("piffio@users.noreply.github.com", "github");
+
+        // Simulate the logic from create_or_get_user
+        let email_to_use = if crate::auth::github::is_noreply_email(&normalized_user.email)
+            && !crate::auth::github::is_noreply_email(&existing_user.email)
+        {
+            existing_user.email.clone()
+        } else {
+            normalized_user.email
+        };
+
+        assert_eq!(email_to_use, "real@gmail.com");
+    }
+
+    #[tokio::test]
+    async fn test_email_preservation_logic_noreply_updated_to_real() {
+        // Test case: Existing user with noreply, GitHub fetch succeeds (returns real email)
+        let existing_user =
+            create_mock_user("user-123", "piffio@users.noreply.github.com", "github");
+        let normalized_user = create_mock_normalized_user("real@gmail.com", "github");
+
+        // Simulate the logic from create_or_get_user
+        let email_to_use = if crate::auth::github::is_noreply_email(&normalized_user.email)
+            && !crate::auth::github::is_noreply_email(&existing_user.email)
+        {
+            existing_user.email.clone()
+        } else {
+            normalized_user.email
+        };
+
+        assert_eq!(email_to_use, "real@gmail.com");
+    }
+
+    #[tokio::test]
+    async fn test_email_preservation_logic_new_user_gets_noreply() {
+        // Test case: New user, GitHub fetch fails (returns noreply)
+        let normalized_user =
+            create_mock_normalized_user("piffio@users.noreply.github.com", "github");
+
+        // Simulate the logic for new users (no existing user to compare with)
+        let email_to_use = normalized_user.email;
+
+        assert_eq!(email_to_use, "piffio@users.noreply.github.com");
+    }
+
+    #[tokio::test]
+    async fn test_email_preservation_logic_both_noreply_unchanged() {
+        // Test case: Existing user with noreply, GitHub fetch fails (returns noreply)
+        let existing_user =
+            create_mock_user("user-123", "piffio@users.noreply.github.com", "github");
+        let normalized_user =
+            create_mock_normalized_user("piffio@users.noreply.github.com", "github");
+
+        // Simulate the logic from create_or_get_user
+        let email_to_use = if crate::auth::github::is_noreply_email(&normalized_user.email)
+            && !crate::auth::github::is_noreply_email(&existing_user.email)
+        {
+            existing_user.email.clone()
+        } else {
+            normalized_user.email
+        };
+
+        assert_eq!(email_to_use, "piffio@users.noreply.github.com");
+    }
+
+    #[tokio::test]
+    async fn test_email_preservation_logic_both_real_updates() {
+        // Test case: Existing user with real email, GitHub fetch succeeds (returns real email)
+        let existing_user = create_mock_user("user-123", "old@gmail.com", "github");
+        let normalized_user = create_mock_normalized_user("new@gmail.com", "github");
+
+        // Simulate the logic from create_or_get_user
+        let email_to_use = if crate::auth::github::is_noreply_email(&normalized_user.email)
+            && !crate::auth::github::is_noreply_email(&existing_user.email)
+        {
+            existing_user.email.clone()
+        } else {
+            normalized_user.email
+        };
+
+        assert_eq!(email_to_use, "new@gmail.com");
+    }
 }
 
 // Helper module for URL encoding

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -1044,6 +1044,122 @@ pub async fn unsuspend_user(db: &D1Database, user_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Delete a user and all their associated data
+/// Returns counts of deleted records for audit purposes
+pub async fn delete_user(
+    db: &D1Database,
+    user_id: &str,
+    _deleted_by: &str,
+) -> Result<(usize, usize, usize)> {
+    // Delete in order to respect foreign key constraints:
+
+    // 1. Delete analytics events for the user's links
+    let analytics_stmt = db.prepare(
+        "DELETE FROM analytics_events WHERE link_id IN (SELECT id FROM links WHERE created_by = ?1)"
+    );
+    let analytics_result = analytics_stmt.bind(&[user_id.into()])?.run().await?;
+    let analytics_count = analytics_result
+        .meta()?
+        .and_then(|m| m.changes)
+        .unwrap_or(0);
+
+    // 2. Delete link reports where user is reporter or reviewer
+    let reports_stmt =
+        db.prepare("DELETE FROM link_reports WHERE reporter_user_id = ?1 OR reviewed_by = ?2");
+    let reports_result = reports_stmt
+        .bind(&[user_id.into(), user_id.into()])?
+        .run()
+        .await?;
+    let _reports_count = reports_result.meta()?.and_then(|m| m.changes).unwrap_or(0);
+
+    // 3. Delete links created by the user
+    let links_stmt = db.prepare("DELETE FROM links WHERE created_by = ?1");
+    let links_result = links_stmt.bind(&[user_id.into()])?.run().await?;
+    let links_count = links_result.meta()?.and_then(|m| m.changes).unwrap_or(0);
+
+    // 4. Delete organization memberships
+    let org_members_stmt = db.prepare("DELETE FROM org_members WHERE user_id = ?1");
+    let org_members_result = org_members_stmt.bind(&[user_id.into()])?.run().await?;
+    let _org_members_count = org_members_result
+        .meta()?
+        .and_then(|m| m.changes)
+        .unwrap_or(0);
+
+    // 5. Delete organization invitations created by this user
+    let invitations_stmt = db.prepare("DELETE FROM org_invitations WHERE invited_by = ?1");
+    let invitations_result = invitations_stmt.bind(&[user_id.into()])?.run().await?;
+    let _invitations_count = invitations_result
+        .meta()?
+        .and_then(|m| m.changes)
+        .unwrap_or(0);
+
+    // 6. Delete blacklist entries created by this user
+    let blacklist_stmt = db.prepare("DELETE FROM destination_blacklist WHERE created_by = ?1");
+    let blacklist_result = blacklist_stmt.bind(&[user_id.into()])?.run().await?;
+    let _blacklist_count = blacklist_result
+        .meta()?
+        .and_then(|m| m.changes)
+        .unwrap_or(0);
+
+    // 7. Finally, delete the user record
+    let user_stmt = db.prepare("DELETE FROM users WHERE id = ?1");
+    let user_result = user_stmt.bind(&[user_id.into()])?.run().await?;
+    let user_count = user_result.meta()?.and_then(|m| m.changes).unwrap_or(0);
+
+    Ok((user_count, links_count, analytics_count))
+}
+
+/// Check if user is the last admin in their organization
+pub async fn is_last_admin_in_org(db: &D1Database, user_id: &str, org_id: &str) -> Result<bool> {
+    let stmt = db.prepare(
+        "SELECT COUNT(*) as admin_count FROM users WHERE org_id = ?1 AND role = 'admin' AND id != ?2"
+    );
+    let result = stmt
+        .bind(&[org_id.into(), user_id.into()])?
+        .first::<serde_json::Value>(None)
+        .await?;
+
+    let admin_count = result
+        .as_ref()
+        .and_then(|v| v.get("admin_count"))
+        .and_then(|count| count.as_u64())
+        .unwrap_or(0);
+
+    Ok(admin_count == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_delete_user_logic_order() {
+        // Test that the deletion order is correct to avoid FK violations
+        // This is a conceptual test - actual database testing would require mocks
+
+        // Expected order:
+        // 1. analytics_events (references links)
+        // 2. link_reports (references users)
+        // 3. links (references users)
+        // 4. org_members (references users)
+        // 5. org_invitations (references users)
+        // 6. destination_blacklist (references users)
+        // 7. users (the main record)
+
+        // This order ensures we delete children before parents
+        let expected_order = vec![
+            "analytics_events",
+            "link_reports",
+            "links",
+            "org_members",
+            "org_invitations",
+            "destination_blacklist",
+            "users",
+        ];
+
+        // The actual implementation follows this order
+        assert_eq!(expected_order.len(), 7); // Verify we have all tables
+    }
+}
+
 /// Disable all links for a user
 pub async fn disable_all_links_for_user(db: &D1Database, user_id: &str) -> Result<i64> {
     let now = now_timestamp();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,7 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
             "/api/admin/users/:id/unsuspend",
             router::handle_admin_unsuspend_user,
         )
+        .delete_async("/api/admin/users/:id", router::handle_admin_delete_user)
         // Admin report management routes
         .get_async("/api/admin/reports", router::handle_admin_get_reports)
         .get_async("/api/admin/reports/:id", router::handle_admin_get_report)

--- a/src/router.rs
+++ b/src/router.rs
@@ -1105,6 +1105,21 @@ pub async fn handle_oauth_callback(req: Request, ctx: RouteContext<()>) -> Resul
                     headers.set("Location", &redirect_url)?;
                     return Ok(Response::empty()?.with_status(302).with_headers(headers));
                 }
+
+                // Check if email is already used by different provider
+                if error_msg.contains("EMAIL_ALREADY_USED") {
+                    let frontend_url = ctx
+                        .env
+                        .var("FRONTEND_URL")
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|_| "http://localhost:5173".to_string());
+
+                    let redirect_url = format!("{}/login?error=email_already_used", frontend_url);
+                    let headers = Headers::new();
+                    headers.set("Location", &redirect_url)?;
+                    return Ok(Response::empty()?.with_status(302).with_headers(headers));
+                }
+
                 return Err(e);
             }
         };
@@ -2312,6 +2327,70 @@ pub async fn handle_admin_unsuspend_user(req: Request, ctx: RouteContext<()>) ->
     Response::from_json(&serde_json::json!({
         "success": true,
         "message": "User unsuspended successfully"
+    }))
+}
+
+/// Handle deleting a user: DELETE /api/admin/users/:id (admin only)
+pub async fn handle_admin_delete_user(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    let user_ctx = match auth::authenticate_request(&req, &ctx).await {
+        Ok(ctx) => ctx,
+        Err(e) => return Ok(e.into_response()),
+    };
+
+    if let Err(e) = auth::require_admin(&user_ctx) {
+        return Ok(e.into_response());
+    }
+
+    let target_user_id = ctx
+        .param("id")
+        .ok_or_else(|| Error::RustError("Missing user ID".to_string()))?
+        .to_string();
+
+    // Safety guard: Cannot delete self
+    if target_user_id == user_ctx.user_id {
+        return Response::error("Cannot delete your own account", 400);
+    }
+
+    let db = ctx.env.get_binding::<D1Database>("rushomon")?;
+
+    // Get target user info for safety checks
+    let target_user = match db::get_user_by_id(&db, &target_user_id).await? {
+        Some(user) => user,
+        None => return Response::error("User not found", 404),
+    };
+
+    // Safety guard: Cannot delete the last admin in an organization
+    if target_user.role == "admin"
+        && db::is_last_admin_in_org(&db, &target_user_id, &target_user.org_id).await?
+    {
+        return Response::error("Cannot delete the last admin in an organization", 400);
+    }
+
+    // Parse request body for confirmation
+    let body: serde_json::Value = match req.json().await {
+        Ok(body) => body,
+        Err(e) => return Response::error(format!("Invalid JSON: {}", e), 400),
+    };
+
+    let confirmation = body.get("confirmation").and_then(|c| c.as_str());
+    if confirmation != Some("DELETE") {
+        return Response::error("Must provide 'confirmation': 'DELETE' in request body", 400);
+    }
+
+    // Delete user and all their data
+    let (user_count, links_count, analytics_count) =
+        db::delete_user(&db, &target_user_id, &user_ctx.user_id).await?;
+
+    if user_count == 0 {
+        return Response::error("Failed to delete user", 500);
+    }
+
+    Response::from_json(&serde_json::json!({
+        "success": true,
+        "message": "User and all associated data deleted successfully",
+        "deleted_user_count": user_count,
+        "deleted_links_count": links_count,
+        "deleted_analytics_count": analytics_count
     }))
 }
 

--- a/tests/admin_deletion_test.rs
+++ b/tests/admin_deletion_test.rs
@@ -1,0 +1,176 @@
+use reqwest;
+use serde_json::json;
+
+mod common;
+
+#[tokio::test]
+async fn test_admin_delete_user_with_confirmation() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // Get admin JWT token
+    let admin_token = common::get_admin_jwt(&client, &base_url).await;
+
+    // Create a test user to delete via the regular OAuth flow
+    // This would normally be done through the mock OAuth server
+    // For now, we'll test the API endpoint structure
+
+    // Test that the delete endpoint exists and requires proper authentication
+    let fake_user_id = "test-user-id";
+
+    let response = client
+        .delete(&format!("{}/api/admin/users/{}", base_url, fake_user_id))
+        .header("Authorization", &format!("Bearer {}", admin_token))
+        .json(&json!({"confirmation": "DELETE"}))
+        .send()
+        .await
+        .expect("Failed to call delete endpoint");
+
+    // Should return 404 for non-existent user, confirming the endpoint works
+    assert_eq!(response.status(), 404);
+}
+
+#[tokio::test]
+async fn test_admin_delete_without_confirmation_fails() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // Get admin JWT token
+    let admin_token = common::get_admin_jwt(&client, &base_url).await;
+
+    // Try to delete without confirmation
+    let response = client
+        .delete(&format!("{}/api/admin/users/test-user", base_url))
+        .header("Authorization", &format!("Bearer {}", admin_token))
+        .json(&json!({})) // Empty body, no confirmation
+        .send()
+        .await
+        .expect("Failed to attempt deletion without confirmation");
+
+    // Should fail due to missing confirmation OR user not found
+    // The actual behavior depends on whether the endpoint validates confirmation first
+    let status = response.status();
+    assert!(status == 400 || status == 404);
+
+    if status == 400 {
+        // Try to parse the error response
+        if let Ok(error_response) = response.json::<serde_json::Value>().await {
+            if let Some(error_message) = error_response["error"].as_str() {
+                assert!(error_message.contains("confirmation"));
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_admin_delete_non_admin_fails() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // In integration tests, we only have admin users
+    // So this test verifies that the endpoint works and returns appropriate response
+    // The actual permission testing would require setting up separate user roles
+
+    // Get admin JWT token (using the only available user in test env)
+    let admin_token = common::get_admin_jwt(&client, &base_url).await;
+
+    // Try to delete as admin (this should work for endpoint testing)
+    let response = client
+        .delete(&format!("{}/api/admin/users/test-user", base_url))
+        .header("Authorization", &format!("Bearer {}", admin_token))
+        .json(&json!({"confirmation": "DELETE"}))
+        .send()
+        .await
+        .expect("Failed to attempt deletion");
+
+    // Should return 404 for non-existent user (endpoint works)
+    // In a real multi-user environment, this would be 403 for non-admin
+    assert!(response.status() == 404 || response.status() == 403);
+}
+
+#[tokio::test]
+async fn test_admin_delete_user_not_found() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // Get admin JWT token
+    let admin_token = common::get_admin_jwt(&client, &base_url).await;
+
+    // Try to delete non-existent user
+    let fake_user_id = "non-existent-user-id";
+
+    let response = client
+        .delete(&format!("{}/api/admin/users/{}", base_url, fake_user_id))
+        .header("Authorization", &format!("Bearer {}", admin_token))
+        .json(&json!({"confirmation": "DELETE"}))
+        .send()
+        .await
+        .expect("Failed to attempt deletion of non-existent user");
+
+    // Should return 404 for non-existent user
+    assert_eq!(response.status(), 404);
+
+    // Try to parse error response, but handle case where it's plain text
+    let error_text = response
+        .text()
+        .await
+        .unwrap_or_else(|_| "No error text".to_string());
+    assert!(
+        error_text.contains("not found")
+            || error_text.contains("User not found")
+            || error_text.contains("404")
+    );
+}
+
+#[tokio::test]
+async fn test_admin_delete_endpoint_requires_auth() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // Try to delete without any authentication
+    let response = client
+        .delete(&format!("{}/api/admin/users/test-user", base_url))
+        .json(&json!({"confirmation": "DELETE"}))
+        .send()
+        .await
+        .expect("Failed to attempt unauthenticated deletion");
+
+    // Should fail due to missing authentication
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn test_admin_users_list_accessible() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // Get admin JWT token
+    let admin_token = common::get_admin_jwt(&client, &base_url).await;
+
+    // Test that we can list users (this should work)
+    let response = client
+        .get(&format!("{}/api/admin/users", base_url))
+        .header("Authorization", &format!("Bearer {}", admin_token))
+        .send()
+        .await
+        .expect("Failed to list users");
+
+    assert_eq!(response.status(), 200);
+
+    let users_response: serde_json::Value = response
+        .json()
+        .await
+        .expect("Failed to parse users response");
+    let users = users_response["users"]
+        .as_array()
+        .expect("Users should be an array");
+
+    // Should have at least our test admin user
+    assert!(users.len() >= 1);
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -127,3 +127,19 @@ pub fn unique_short_code(prefix: &str) -> String {
         .as_millis();
     format!("{}{}", prefix, timestamp % 100000)
 }
+
+/// Get admin JWT token for testing admin functionality
+/// Uses the existing test JWT from the integration test environment
+pub async fn get_admin_jwt(_client: &Client, _base_url: &str) -> String {
+    // For integration tests, we use the existing TEST_JWT
+    // The test environment sets up an admin user automatically
+    get_test_jwt()
+}
+
+/// Get regular user JWT token for testing user functionality
+/// Uses the existing test JWT (integration tests use admin user for simplicity)
+pub async fn get_user_jwt(_client: &Client, _base_url: &str) -> String {
+    // For integration tests, we use the same TEST_JWT
+    // In a real scenario, you'd create a separate user via OAuth
+    get_test_jwt()
+}

--- a/tests/oauth_email_conflict_test.rs
+++ b/tests/oauth_email_conflict_test.rs
@@ -1,0 +1,112 @@
+use reqwest;
+
+mod common;
+
+#[tokio::test]
+async fn test_oauth_callback_endpoint_exists() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // Test that the OAuth callback endpoint exists and handles requests
+    let response = client
+        .get(&format!(
+            "{}/api/auth/callback?code=test&state=test",
+            base_url
+        ))
+        .send()
+        .await
+        .expect("Failed to call OAuth callback");
+
+    // Should either succeed, redirect, return error, or unauthorized
+    // The exact behavior depends on the mock OAuth server setup and state
+    let status = response.status();
+    assert!(
+        status.is_success() || status == 302 || status == 400 || status == 401 || status == 500,
+        "Unexpected status code: {}",
+        status
+    );
+}
+
+#[tokio::test]
+async fn test_oauth_provider_compatibility() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // Test that different OAuth providers are available
+    let response = client
+        .get(&format!("{}/api/auth/providers", base_url))
+        .send()
+        .await
+        .expect("Failed to get auth providers");
+
+    assert_eq!(response.status(), 200);
+
+    let providers: serde_json::Value = response
+        .json()
+        .await
+        .expect("Failed to parse providers response");
+    let providers_array = providers["providers"]
+        .as_array()
+        .expect("Providers should be an array");
+
+    // Should have at least GitHub and Google available
+    assert!(providers_array.len() >= 2);
+
+    let provider_names: Vec<&str> = providers_array
+        .iter()
+        .filter_map(|p| p["name"].as_str())
+        .collect();
+
+    assert!(provider_names.contains(&"github"));
+    assert!(provider_names.contains(&"google"));
+}
+
+#[tokio::test]
+async fn test_oauth_me_endpoint_works() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // Test that the /api/auth/me endpoint works with our test JWT
+    let jwt = common::get_test_jwt();
+
+    let response = client
+        .get(&format!("{}/api/auth/me", base_url))
+        .header("Authorization", &format!("Bearer {}", jwt))
+        .send()
+        .await
+        .expect("Failed to call auth/me endpoint");
+
+    assert_eq!(response.status(), 200);
+
+    let user_info: serde_json::Value = response.json().await.expect("Failed to parse user info");
+
+    // Should have user information
+    assert!(user_info["id"].as_str().is_some());
+    assert!(user_info["email"].as_str().is_some());
+    assert!(user_info["oauth_provider"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn test_oauth_logout_endpoint_works() {
+    let client = reqwest::Client::new();
+    let base_url =
+        std::env::var("TEST_BASE_URL").unwrap_or_else(|_| "http://localhost:8787".to_string());
+
+    // Test that the logout endpoint works
+    let response = client
+        .post(&format!("{}/api/auth/logout", base_url))
+        .send()
+        .await
+        .expect("Failed to call logout endpoint");
+
+    // Should succeed, redirect, or return appropriate status
+    let status = response.status();
+    assert!(
+        status.is_success() || status == 302 || status == 401,
+        "Unexpected logout status: {}",
+        status
+    );
+}


### PR DESCRIPTION
- Fetch the actual user email when using GitHub OAuth
- Gracefully handled email conflicts across different auth providers
- Add the possibility for admins to delete users
- Add unit and integration tests

Closes #119 
Closes #53 