### PR TITLE
fix: always add owners to org_members for free billing accounts

### DIFF
--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -86,9 +86,10 @@
 	const currentOrg = $derived(orgs.find((o) => o.id === currentOrgId));
 	const canCreateOrg = $derived(() => {
 		if (!currentOrg || !orgs) return false;
-		// Business tier allows up to 3 organizations
+		// Only business organization owners can create new organizations
 		const tier = currentOrg.tier;
-		if (tier === "business" || tier === "unlimited") {
+		const role = currentOrg.role;
+		if ((tier === "business" || tier === "unlimited") && role === "owner") {
 			const ownedOrgs = orgs.filter((o) => o.role === "owner");
 			return ownedOrgs.length < 3;
 		}
@@ -105,7 +106,12 @@
 		);
 	});
 	const hasReachedOrgLimit = $derived(() => {
-		return isBusinessTier() && ownedOrgCount() >= 3;
+		return (
+			currentOrg &&
+			isBusinessTier() &&
+			currentOrg.role === "owner" &&
+			ownedOrgCount() >= 3
+		);
 	});
 
 	function openCreateOrg() {
@@ -292,8 +298,16 @@
 														>
 														<span
 															class="block text-xs text-gray-500 capitalize"
-															>{org.role} · {org.tier}</span
 														>
+															{org.role} · {org.tier}
+															{#if org.role === "owner"}
+																<span
+																	class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 ml-1"
+																>
+																	Personal
+																</span>
+															{/if}
+														</span>
 													</span>
 													{#if org.id === currentOrgId}
 														<svg
@@ -360,6 +374,52 @@
 												<span
 													>{ownedOrgCount()}/3
 													organizations created</span
+												>
+											</div>
+										{:else if !isBusinessTier()}
+											<div
+												class="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-400 cursor-default select-none"
+											>
+												<svg
+													class="w-4 h-4"
+													fill="none"
+													stroke="currentColor"
+													viewBox="0 0 24 24"
+												>
+													<path
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														stroke-width="2"
+														d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+													/>
+												</svg>
+												<span>Create Organization</span>
+												<span
+													class="ml-auto text-xs bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded font-medium"
+													>Business</span
+												>
+											</div>
+										{:else if currentOrg && currentOrg.role !== "owner"}
+											<div
+												class="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-400 cursor-default select-none"
+											>
+												<svg
+													class="w-4 h-4"
+													fill="none"
+													stroke="currentColor"
+													viewBox="0 0 24 24"
+												>
+													<path
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														stroke-width="2"
+														d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+													/>
+												</svg>
+												<span>Create Organization</span>
+												<span
+													class="ml-auto text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded font-medium"
+													>Owner Only</span
 												>
 											</div>
 										{:else}

--- a/migrations/0019_fix_org_dropdown.sql
+++ b/migrations/0019_fix_org_dropdown.sql
@@ -1,0 +1,10 @@
+-- Migration 0019: Fix organization dropdown by ensuring all users have org_members records
+-- Add missing org_members records for users who own their default organization
+-- but don't have corresponding org_members entries
+INSERT INTO org_members (org_id, user_id, role, joined_at)
+SELECT u.org_id, u.id, 'owner', u.created_at
+FROM users u
+LEFT JOIN org_members m ON u.org_id = m.org_id AND u.id = m.user_id
+WHERE u.org_id IS NOT NULL
+AND m.user_id IS NULL
+ON CONFLICT(org_id, user_id) DO NOTHING;

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -409,6 +409,9 @@ async fn create_or_get_user(
     };
     let user = queries::create_or_update_user(db, create_data, &org.id).await?;
 
+    // Add the user as an organization member with owner role
+    queries::add_org_member(db, &org.id, &user.id, "owner").await?;
+
     // Update the billing account owner to the actual user ID
     queries::update_billing_account_owner(db, org.billing_account_id.as_ref().unwrap(), &user.id)
         .await?;

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -1964,8 +1964,7 @@ pub struct OrgTag {
 use crate::models::{OrgInvitation, OrgMember, OrgMemberWithUser, OrgWithRole};
 
 /// Get all organizations a user belongs to (via org_members junction table).
-/// Falls back to the user's default org_id if no org_members rows exist yet,
-/// and auto-inserts the missing membership row to self-heal.
+/// After migration, all users should have proper org_members records.
 pub async fn get_user_orgs(db: &D1Database, user_id: &str) -> Result<Vec<OrgWithRole>> {
     let stmt = db.prepare(
         "SELECT o.id, o.name, m.role, m.joined_at
@@ -1976,6 +1975,8 @@ pub async fn get_user_orgs(db: &D1Database, user_id: &str) -> Result<Vec<OrgWith
     );
     let results = stmt.bind(&[user_id.into()])?.all().await?;
     let rows = results.results::<serde_json::Value>()?;
+
+    // Convert rows to OrgWithRole objects
     let orgs: Vec<OrgWithRole> = rows
         .iter()
         .filter_map(|row| {
@@ -1988,48 +1989,7 @@ pub async fn get_user_orgs(db: &D1Database, user_id: &str) -> Result<Vec<OrgWith
         })
         .collect();
 
-    if !orgs.is_empty() {
-        return Ok(orgs);
-    }
-
-    // No org_members rows — fall back to users.org_id and auto-heal
-    let user_row = db
-        .prepare("SELECT org_id, created_at FROM users WHERE id = ?1")
-        .bind(&[user_id.into()])?
-        .first::<serde_json::Value>(None)
-        .await?;
-
-    let Some(user_row) = user_row else {
-        return Ok(vec![]);
-    };
-
-    let Some(org_id) = user_row["org_id"].as_str() else {
-        return Ok(vec![]);
-    };
-    let joined_at = user_row["created_at"].as_f64().unwrap_or(0.0) as i64;
-
-    // Insert the missing membership row (ignore conflicts)
-    db.prepare(
-        "INSERT INTO org_members (org_id, user_id, role, joined_at)
-         VALUES (?1, ?2, 'owner', ?3)
-         ON CONFLICT(org_id, user_id) DO NOTHING",
-    )
-    .bind(&[org_id.into(), user_id.into(), (joined_at as f64).into()])?
-    .run()
-    .await?;
-
-    // Now fetch the org details
-    let org = match get_org_by_id(db, org_id).await? {
-        Some(o) => o,
-        None => return Ok(vec![]),
-    };
-
-    Ok(vec![OrgWithRole {
-        id: org.id,
-        name: org.name,
-        role: "owner".to_string(),
-        joined_at,
-    }])
+    Ok(orgs) // No fallback needed after migration
 }
 
 /// Get the membership record for a specific user in a specific org.

--- a/tests/orgs_test.rs
+++ b/tests/orgs_test.rs
@@ -637,37 +637,6 @@ async fn test_remove_member_not_in_org_returns_404() {
 }
 
 #[tokio::test]
-async fn test_remove_last_owner_is_rejected() {
-    let client = authenticated_client();
-    let org_id = get_primary_test_org_id().await;
-
-    // Get the real user ID from /api/auth/me (not the hardcoded "1000" which is a test fixture)
-    let me: Value = client
-        .get(format!("{}/api/auth/me", BASE_URL))
-        .send()
-        .await
-        .unwrap()
-        .json()
-        .await
-        .unwrap();
-    let user_id = me["id"].as_str().expect("should have id").to_string();
-
-    // Trying to remove yourself as the last owner should fail
-    let response = client
-        .delete(format!(
-            "{}/api/orgs/{}/members/{}",
-            BASE_URL, org_id, user_id
-        ))
-        .send()
-        .await
-        .unwrap();
-    // Should be rejected — last owner can't be removed
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-}
-
-// ─── Delete Org ───────────────────────────────────────────────────────────────
-
-#[tokio::test]
 async fn test_delete_org_requires_auth() {
     let client = test_client();
     let response = client
@@ -827,3 +796,34 @@ async fn test_billing_account_tier_reflected_in_org_tier() {
         tier
     );
 }
+
+#[tokio::test]
+async fn test_remove_last_owner_is_rejected() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    // Get the real user ID from /api/auth/me (not the hardcoded "1000" which is a test fixture)
+    let me: Value = client
+        .get(format!("{}/api/auth/me", BASE_URL))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let user_id = me["id"].as_str().expect("should have id").to_string();
+
+    // Trying to remove yourself as the last owner should fail
+    let response = client
+        .delete(format!(
+            "{}/api/orgs/{}/members/{}",
+            BASE_URL, org_id, user_id
+        ))
+        .send()
+        .await
+        .unwrap();
+    // Should be rejected — last owner can't be removed
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ─── Delete Org ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
This changes the logic and makes it consistent with paid billing accounts. Side effect: the two BA and orgs are now correctly visible in the user's dashboard.

Closes #122 