### PR TITLE
fix: resolve setup script crashes

### DIFF
--- a/scripts/lib/cloudflare.sh
+++ b/scripts/lib/cloudflare.sh
@@ -11,6 +11,9 @@
 #   - Resource management
 #
 
+# Suppress wrangler update warnings that break jq JSON parsing
+export WRANGLER_LOG="error"
+
 # Source common utilities if not already loaded
 if [ -z "$BLUE" ]; then
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/lib/deployment.sh
+++ b/scripts/lib/deployment.sh
@@ -109,7 +109,7 @@ EOF
   fi
 
   # Add Polar configuration if enabled
-  if [ "$POLAR_ENABLED" = true ] && [ -n "$POLAR_ACCESS_TOKEN" ]; then
+  if [ "${POLAR_ENABLED:-false}" = true ] && [ -n "${POLAR_ACCESS_TOKEN:-}" ]; then
     cat >> "$output_file" <<EOF
 POLAR_PRO_MONTHLY_PRODUCT_ID = "${POLAR_PRO_MONTHLY_PRODUCT_ID:-}"
 POLAR_PRO_ANNUAL_PRODUCT_ID = "${POLAR_PRO_ANNUAL_PRODUCT_ID:-}"
@@ -336,7 +336,7 @@ set_worker_secrets() {
   fi
 
   # Set Polar secrets (if enabled)
-  if [ "$POLAR_ENABLED" = true ] && [ -n "$POLAR_ACCESS_TOKEN" ]; then
+  if [ "${POLAR_ENABLED:-false}" = true ] && [ -n "${POLAR_ACCESS_TOKEN:-}" ]; then
     echo "$POLAR_ACCESS_TOKEN" | wrangler secret put POLAR_ACCESS_TOKEN --config "$config_file" || {
       error "Failed to set POLAR_ACCESS_TOKEN"
       return 1


### PR DESCRIPTION
This patch fixes two issues that cause the setup script to fail:

- Suppressed wrangler update notifications (WRANGLER_LOG="error") in cloudflare.sh to prevent CLI warnings from breaking jq parsing during D1/KV resource lookups.
- Added bash parameter expansion fallbacks (${VAR:-}) to Polar billing variables in deployment.sh to prevent 'unbound variable' crashes when the script runs in strict mode and the user skips the optional Polar setup.