### PR TITLE
feat: clearly indicate when counters reset

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -844,6 +844,22 @@ Rushomon includes a tier system with **Free** and **Unlimited** plans. As a self
 - Full analytics retention (all time)
 - Complete feature access
 
+### Monthly Counter Reset Time
+
+Monthly link counters reset at **midnight UTC (00:00 UTC)** on the first day of each calendar month.
+
+**Why UTC?**
+- Ensures consistent billing across all timezones
+- Prevents exploitation through timezone changes
+- Industry standard (AWS, Stripe, and most SaaS platforms use UTC)
+
+**Example:**
+- User in New York (UTC-5): Counter resets at 7:00 PM EST
+- User in London (UTC+0): Counter resets at 12:00 AM GMT
+- User in Tokyo (UTC+9): Counter resets at 9:00 AM JST
+
+The dashboard shows the next reset date with a countdown timer in your local timezone.
+
 ### First User Setup
 
 The first user to sign in to your instance automatically becomes the **instance admin**. However, they start on the **Free tier** by default. You should upgrade them:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "chart.js": "^4.5.1",
         "i18n-iso-countries": "^7.14.0",

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -163,6 +163,10 @@ export interface UsageResponse {
 		links_created_this_month: number;
 		tags_count: number;
 	};
+	next_reset?: {
+		utc: string;
+		timestamp: number;
+	};
 }
 
 // Admin moderation types

--- a/frontend/src/routes/admin/billing/+page.svelte
+++ b/frontend/src/routes/admin/billing/+page.svelte
@@ -426,6 +426,20 @@
 												></div>
 											</div>
 										{/if}
+										{#if details.usage.max_links_per_month}
+											{@const now = Date.now() / 1000}
+											{@const nextReset = new Date()}
+											{@const nextResetTimestamp = (nextReset.setUTCMonth(nextReset.getUTCMonth() + 1, 1), nextReset.setUTCHours(0, 0, 0, 0), nextReset.getTime() / 1000)}
+											{@const diffSeconds = nextResetTimestamp - now}
+											{@const diffDays = Math.floor(diffSeconds / (60 * 60 * 24))}
+											{@const diffHours = Math.floor((diffSeconds % (60 * 60 * 24)) / (60 * 60))}
+											{@const diffMinutes = Math.floor((diffSeconds % (60 * 60)) / 60)}
+											{@const countdownText = diffDays > 0 ? `in ${diffDays}d ${diffHours}h` : diffHours > 0 ? `in ${diffHours}h ${diffMinutes}m` : `in ${diffMinutes}m`}
+											{@const resetDateStr = nextReset.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+											<div class="reset-info">
+												Resets {resetDateStr} UTC (00:00) {countdownText}
+											</div>
+										{/if}
 									</div>
 								</div>
 
@@ -1147,6 +1161,13 @@
 		height: 100%;
 		background: linear-gradient(to right, #3b82f6, #2563eb);
 		transition: width 0.3s;
+	}
+
+	.reset-info {
+		margin-top: 0.5rem;
+		font-size: 0.75rem;
+		color: #64748b;
+		font-style: italic;
 	}
 
 	.no-orgs {

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -101,9 +101,51 @@
 	let linksAtLimit = $derived(
 		usage?.limits.max_links_per_month
 			? usage.usage.links_created_this_month >=
-					usage.limits.max_links_per_month
+				usage.limits.max_links_per_month
 			: false,
 	);
+
+	// Calculate reset countdown
+	type ResetInfo = { text: string; date: string } | null;
+	let resetInfo = $state<ResetInfo>(null);
+
+	$effect(() => {
+		if (!usage?.next_reset?.timestamp) {
+			resetInfo = null;
+			return;
+		}
+		const now = Date.now() / 1000;
+		const diffSeconds = usage.next_reset.timestamp - now;
+
+		if (diffSeconds <= 0) {
+			// Reset time passed, refresh the page to get new usage data
+			setTimeout(() => window.location.reload(), 5000);
+			resetInfo = { text: "Refreshing...", date: "" };
+			return;
+		}
+
+		const diffDays = Math.floor(diffSeconds / (60 * 60 * 24));
+		const diffHours = Math.floor((diffSeconds % (60 * 60 * 24)) / (60 * 60));
+		const diffMinutes = Math.floor((diffSeconds % (60 * 60)) / 60);
+
+		let text = "";
+		if (diffDays > 0) {
+			text = `in ${diffDays}d ${diffHours}h`;
+		} else if (diffHours > 0) {
+			text = `in ${diffHours}h ${diffMinutes}m`;
+		} else {
+			text = `in ${diffMinutes}m`;
+		}
+
+		// Format reset date in user's local timezone
+		const resetDate = new Date(usage.next_reset.timestamp * 1000);
+		const dateStr = resetDate.toLocaleDateString(undefined, {
+			month: "short",
+			day: "numeric",
+		});
+
+		resetInfo = { text, date: dateStr };
+	});
 
 	// Helper to refresh all dashboard data (stats, usage, links)
 	async function refreshDashboardData() {
@@ -474,39 +516,46 @@
 				<!-- Usage counter for tiers with limits -->
 				{#if usage && usage.limits.max_links_per_month}
 					<span class="text-gray-300 hidden sm:inline">·</span>
-					<span class="flex items-center gap-2 text-sm">
-						<span class="text-gray-500">This month:</span>
-						<span
-							class="font-semibold {linksAtLimit
-								? 'text-red-600'
-								: 'text-gray-900'}"
-						>
-							{usage.usage.links_created_this_month} / {usage
-								.limits.max_links_per_month}
-						</span>
-						<div
-							class="w-20 bg-gray-200 rounded-full h-1.5 hidden sm:block"
-						>
+					<span class="flex flex-col gap-1 text-sm">
+						<span class="flex items-center gap-2">
+							<span class="text-gray-500">This month:</span>
+							<span
+								class="font-semibold {linksAtLimit
+									? 'text-red-600'
+									: 'text-gray-900'}"
+							>
+								{usage.usage.links_created_this_month} / {usage
+									.limits.max_links_per_month}
+							</span>
 							<div
-								class="h-1.5 rounded-full transition-all duration-500 {linksAtLimit
-									? 'bg-red-500'
-									: linksUsagePercent >= 80
-										? 'bg-amber-500'
-										: 'bg-orange-500'}"
-								style="width: {linksUsagePercent}%"
-							></div>
-						</div>
-						{#if linksAtLimit}
-							<span class="text-xs text-red-600 font-medium"
-								>Limit reached</span
+								class="w-20 bg-gray-200 rounded-full h-1.5 hidden sm:block"
 							>
-						{/if}
-						{#if usage.tier === "free"}
-							<a
-								href="/pricing"
-								class="text-xs text-orange-600 hover:text-orange-700 font-medium"
-								>Upgrade →</a
-							>
+								<div
+									class="h-1.5 rounded-full transition-all duration-500 {linksAtLimit
+										? 'bg-red-500'
+										: linksUsagePercent >= 80
+											? 'bg-amber-500'
+											: 'bg-orange-500'}"
+									style="width: {linksUsagePercent}%"
+								></div>
+							</div>
+							{#if linksAtLimit}
+								<span class="text-xs text-red-600 font-medium"
+									>Limit reached</span
+								>
+							{/if}
+							{#if usage.tier === "free"}
+								<a
+									href="/pricing"
+									class="text-xs text-orange-600 hover:text-orange-700 font-medium"
+									>Upgrade →</a
+								>
+							{/if}
+						</span>
+						{#if resetInfo}
+							<span class="text-xs text-gray-400">
+								Resets {resetInfo.date} UTC (00:00) {resetInfo.text}
+							</span>
 						{/if}
 					</span>
 				{/if}

--- a/frontend/src/routes/terms/+page.svelte
+++ b/frontend/src/routes/terms/+page.svelte
@@ -105,7 +105,8 @@
 						</li>
 					</ul>
 					<p class="text-gray-700 leading-relaxed mt-3">
-						Limits reset on the 1st of each calendar month (UTC).
+						Limits reset at <strong>midnight UTC (00:00 UTC)</strong> on the first day of each calendar month.
+						The dashboard shows your usage with a countdown to the next reset in your local timezone.
 						The instance administrator may change your tier at any
 						time. Unused quota does not roll over.
 					</p>

--- a/src/router.rs
+++ b/src/router.rs
@@ -7,7 +7,7 @@ use crate::models::{
     link::{CreateLinkRequest, Link, LinkStatus, UpdateLinkRequest},
 };
 use crate::utils::{generate_short_code, now_timestamp, validate_short_code, validate_url};
-use chrono::Datelike;
+use chrono::{Datelike, TimeZone};
 use std::future::Future;
 use std::pin::Pin;
 use worker::d1::D1Database;
@@ -2028,6 +2028,14 @@ pub async fn handle_get_usage(req: Request, ctx: RouteContext<()>) -> Result<Res
     // Get tag count for the billing account
     let tags_count = db::count_distinct_tags_for_billing_account(&db, &billing_account.id).await?;
 
+    // Calculate next reset time (first day of next month at midnight UTC)
+    let now = chrono::Utc::now();
+    let next_reset = chrono::Utc
+        .with_ymd_and_hms(now.year(), now.month() + 1, 1, 0, 0, 0)
+        .single()
+        .unwrap_or_else(chrono::Utc::now);
+    let next_reset_timestamp = next_reset.timestamp();
+
     let usage = serde_json::json!({
         "tier": tier.as_str(),
         "limits": {
@@ -2041,6 +2049,10 @@ pub async fn handle_get_usage(req: Request, ctx: RouteContext<()>) -> Result<Res
         "usage": {
             "links_created_this_month": links_created_this_month,
             "tags_count": tags_count,
+        },
+        "next_reset": {
+            "utc": next_reset.to_rfc3339(),
+            "timestamp": next_reset_timestamp,
         }
     });
 


### PR DESCRIPTION
- Make it clear we're using UTC time
- Show a countdown until reset time
- Show the same information in the admin dashboard