### PR TITLE
chore: add meta header pointing at the sitemap

### DIFF
--- a/frontend/src/lib/components/SEO.svelte
+++ b/frontend/src/lib/components/SEO.svelte
@@ -55,4 +55,7 @@
 		<meta name="twitter:description" content={props.description} />
 	{/if}
 	<meta name="twitter:image" content={`${siteUrl}/favicon-192x192.png`} />
+
+	<!-- Sitemap reference for search engines -->
+	<link rel="sitemap" type="application/xml" href={`${siteUrl}/sitemap.xml`} />
 </svelte:head>


### PR DESCRIPTION
This should improve the situation with Google Search not being able to fetch the Sitemap 