### PR TITLE
fix: strip avatar referrer header to resolve 429 errors

### DIFF
--- a/frontend/src/lib/components/Avatar.svelte
+++ b/frontend/src/lib/components/Avatar.svelte
@@ -32,6 +32,7 @@
 		src={user.avatar_url}
 		alt={displayName}
 		class="{sizeClass} rounded-full {className}"
+		referrerpolicy="no-referrer"
 	/>
 {:else}
 	<div

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -530,6 +530,7 @@
                                 <img
                                     src={user.avatar_url}
                                     alt={user.name || user.email}
+                                    referrerpolicy="no-referrer"
                                 />
                             {:else}
                                 <span

--- a/frontend/src/routes/admin/users/+page.svelte
+++ b/frontend/src/routes/admin/users/+page.svelte
@@ -252,6 +252,7 @@
 										src={user.avatar_url}
 										alt={user.name || user.email}
 										class="avatar"
+										referrerpolicy="no-referrer"
 									/>
 								{:else}
 									<div class="avatar-placeholder">
@@ -355,6 +356,7 @@
 												src={user.avatar_url}
 												alt={user.name || user.email}
 												class="avatar"
+												referrerpolicy="no-referrer"
 											/>
 										{:else}
 											<div class="avatar-placeholder">


### PR DESCRIPTION
Simple fix so that avatars load correctly from google cdn.