### PR TITLE
refactor: lib.rs cleanup, AppError, and tags retro-fit

### DIFF
--- a/src/api/tags/delete.rs
+++ b/src/api/tags/delete.rs
@@ -3,6 +3,7 @@
 /// Delete a tag from the authenticated user's organization.
 use crate::auth;
 use crate::services::TagService;
+use crate::utils::AppError;
 use worker::d1::D1Database;
 use worker::*;
 
@@ -28,42 +29,27 @@ use worker::*;
     )
 )]
 pub async fn handle_delete_org_tag(req: Request, ctx: RouteContext<()>) -> Result<Response> {
-    let user_ctx = match auth::authenticate_request(&req, &ctx).await {
-        Ok(ctx) => ctx,
-        Err(e) => return Ok(e.into_response()),
-    };
+    Ok(inner(req, ctx).await.unwrap_or_else(|e| e.into_response()))
+}
 
-    let tag_name = match ctx.param("name") {
-        Some(name) => urlencoding::decode(name).unwrap_or_default().into_owned(),
-        None => return Response::error("Missing tag name", 400),
-    };
+async fn inner(req: Request, ctx: RouteContext<()>) -> Result<Response, AppError> {
+    let user_ctx = auth::authenticate_request(&req, &ctx).await?;
+
+    let tag_name = ctx
+        .param("name")
+        .map(|n| urlencoding::decode(n).unwrap_or_default().into_owned())
+        .ok_or_else(|| AppError::BadRequest("Missing tag name".to_string()))?;
 
     let db = ctx.env.get_binding::<D1Database>("rushomon")?;
     let tag_service = TagService::new();
 
-    match tag_service
+    let deleted = tag_service
         .delete_tag(&db, &user_ctx.org_id, &tag_name)
-        .await
-    {
-        Ok(deleted) => {
-            if deleted {
-                Ok(Response::empty()?.with_status(204))
-            } else {
-                Response::error("Tag not found", 404)
-            }
-        }
-        Err(e) => {
-            console_log!(
-                "{}",
-                serde_json::json!({
-                    "event": "delete_tag_failed",
-                    "org_id": user_ctx.org_id,
-                    "tag_name": tag_name,
-                    "error": e.to_string(),
-                    "level": "error"
-                })
-            );
-            Response::error("Failed to delete tag", 500)
-        }
+        .await?;
+
+    if deleted {
+        Ok(Response::empty()?.with_status(204))
+    } else {
+        Err(AppError::NotFound("Tag not found".to_string()))
     }
 }

--- a/src/api/tags/list.rs
+++ b/src/api/tags/list.rs
@@ -3,6 +3,7 @@
 /// Get all tags for the authenticated user's organization with usage counts.
 use crate::auth;
 use crate::services::TagService;
+use crate::utils::AppError;
 use worker::d1::D1Database;
 use worker::*;
 
@@ -22,15 +23,13 @@ use worker::*;
     )
 )]
 pub async fn handle_get_org_tags(req: Request, ctx: RouteContext<()>) -> Result<Response> {
-    let user_ctx = match auth::authenticate_request(&req, &ctx).await {
-        Ok(ctx) => ctx,
-        Err(e) => return Ok(e.into_response()),
-    };
-    let org_id = &user_ctx.org_id;
+    Ok(inner(req, ctx).await.unwrap_or_else(|e| e.into_response()))
+}
 
+async fn inner(req: Request, ctx: RouteContext<()>) -> Result<Response, AppError> {
+    let user_ctx = auth::authenticate_request(&req, &ctx).await?;
     let db = ctx.env.get_binding::<D1Database>("rushomon")?;
     let tag_service = TagService::new();
-    let tags = tag_service.get_org_tags(&db, org_id).await?;
-
-    Response::from_json(&tags)
+    let tags = tag_service.get_org_tags(&db, &user_ctx.org_id).await?;
+    Ok(Response::from_json(&tags)?)
 }

--- a/src/api/tags/rename.rs
+++ b/src/api/tags/rename.rs
@@ -3,6 +3,7 @@
 /// Rename a tag in the authenticated user's organization.
 use crate::auth;
 use crate::services::TagService;
+use crate::utils::AppError;
 use worker::d1::D1Database;
 use worker::*;
 
@@ -25,49 +26,35 @@ use worker::*;
         ("session_cookie" = [])
     )
 )]
-pub async fn handle_rename_org_tag(mut req: Request, ctx: RouteContext<()>) -> Result<Response> {
-    let user_ctx = match auth::authenticate_request(&req, &ctx).await {
-        Ok(ctx) => ctx,
-        Err(e) => return Ok(e.into_response()),
-    };
+pub async fn handle_rename_org_tag(req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    Ok(inner(req, ctx).await.unwrap_or_else(|e| e.into_response()))
+}
 
-    let old_name = match ctx.param("name") {
-        Some(name) => urlencoding::decode(name).unwrap_or_default().into_owned(),
-        None => return Response::error("Missing tag name", 400),
-    };
+async fn inner(mut req: Request, ctx: RouteContext<()>) -> Result<Response, AppError> {
+    let user_ctx = auth::authenticate_request(&req, &ctx).await?;
 
-    // Parse request body
-    let body: serde_json::Value = match req.json().await {
-        Ok(body) => body,
-        Err(_) => return Response::error("Invalid request body", 400),
-    };
+    let old_name = ctx
+        .param("name")
+        .map(|n| urlencoding::decode(n).unwrap_or_default().into_owned())
+        .ok_or_else(|| AppError::BadRequest("Missing tag name".to_string()))?;
 
-    let new_name = match body.get("new_name").and_then(|v| v.as_str()) {
-        Some(name) => name.to_string(),
-        None => return Response::error("Missing new_name field", 400),
-    };
+    let body: serde_json::Value = req
+        .json()
+        .await
+        .map_err(|_| AppError::BadRequest("Invalid request body".to_string()))?;
+
+    let new_name = body
+        .get("new_name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| AppError::BadRequest("Missing new_name field".to_string()))?
+        .to_string();
 
     let db = ctx.env.get_binding::<D1Database>("rushomon")?;
     let tag_service = TagService::new();
 
-    match tag_service
+    let tags = tag_service
         .rename_tag(&db, &user_ctx.org_id, &old_name, &new_name)
-        .await
-    {
-        Ok(tags) => Response::from_json(&tags),
-        Err(e) => {
-            console_log!(
-                "{}",
-                serde_json::json!({
-                    "event": "rename_tag_failed",
-                    "org_id": user_ctx.org_id,
-                    "old_name": old_name,
-                    "new_name": new_name,
-                    "error": e.to_string(),
-                    "level": "error"
-                })
-            );
-            Response::error("Failed to rename tag", 500)
-        }
-    }
+        .await?;
+
+    Ok(Response::from_json(&tags)?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,13 +168,6 @@ pub(crate) fn add_cors_headers(
     response
 }
 
-/// Handle CORS preflight requests
-async fn handle_cors_preflight(req: Request, ctx: RouteContext<()>) -> Result<Response> {
-    let origin = req.headers().get("Origin").ok().flatten();
-    let response = Response::empty()?;
-    Ok(add_cors_headers(response, origin, &ctx.env))
-}
-
 #[event(fetch)]
 async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
     // Set up panic hook for better error messages
@@ -226,6 +219,12 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
                 // Asset not found or fetch failed, continue to router
             }
         }
+    }
+
+    // Handle CORS preflight for all API routes with a single early-return.
+    if req.method() == Method::Options && path.starts_with("/api/") {
+        let response = Response::empty()?;
+        return Ok(add_cors_headers(response, origin, &env));
     }
 
     // Create router
@@ -299,91 +298,6 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
             }
             Ok(result.response)
         })
-        // CORS preflight handlers for API routes
-        .options_async("/api/auth/providers", handle_cors_preflight)
-        .options_async("/api/auth/github", handle_cors_preflight)
-        .options_async("/api/auth/google", handle_cors_preflight)
-        .options_async("/api/auth/callback", handle_cors_preflight)
-        .options_async("/api/auth/me", handle_cors_preflight)
-        .options_async("/api/auth/refresh", handle_cors_preflight)
-        .options_async("/api/auth/logout", handle_cors_preflight)
-        .options_async("/api/links", handle_cors_preflight)
-        .options_async("/api/links/by-code/:code", handle_cors_preflight)
-        .options_async("/api/links/:id", handle_cors_preflight)
-        .options_async("/api/links/:id/analytics", handle_cors_preflight)
-        .options_async("/api/links/export", handle_cors_preflight)
-        .options_async("/api/links/import", handle_cors_preflight)
-        .options_async("/api/usage", handle_cors_preflight)
-        .options_async("/api/admin/users", handle_cors_preflight)
-        .options_async("/api/admin/users/:id", handle_cors_preflight)
-        .options_async("/api/admin/settings", handle_cors_preflight)
-        .options_async("/api/admin/discounts", handle_cors_preflight)
-        .options_async("/api/admin/products", handle_cors_preflight)
-        .options_async("/api/admin/products/sync", handle_cors_preflight)
-        .options_async("/api/admin/products/save", handle_cors_preflight)
-        .options_async("/api/admin/orgs/:id/tier", handle_cors_preflight)
-        .options_async("/api/admin/billing-accounts", handle_cors_preflight)
-        .options_async("/api/admin/billing-accounts/:id", handle_cors_preflight)
-        .options_async(
-            "/api/admin/billing-accounts/:id/tier",
-            handle_cors_preflight,
-        )
-        .options_async(
-            "/api/admin/billing-accounts/:id/reset-counter",
-            handle_cors_preflight,
-        )
-        .options_async(
-            "/api/admin/billing-accounts/:id/subscription",
-            handle_cors_preflight,
-        )
-        .options_async("/api/admin/orgs/:id/reset-counter", handle_cors_preflight)
-        .options_async("/api/admin/links", handle_cors_preflight)
-        .options_async("/api/admin/links/:id", handle_cors_preflight)
-        .options_async("/api/admin/links/:id/sync-kv", handle_cors_preflight)
-        .options_async("/api/admin/blacklist", handle_cors_preflight)
-        .options_async("/api/admin/blacklist/:id", handle_cors_preflight)
-        .options_async("/api/admin/users/:id/suspend", handle_cors_preflight)
-        .options_async("/api/admin/users/:id/unsuspend", handle_cors_preflight)
-        .options_async("/api/admin/reports", handle_cors_preflight)
-        .options_async("/api/admin/reports/:id", handle_cors_preflight)
-        .options_async("/api/admin/reports/pending/count", handle_cors_preflight)
-        .options_async("/api/reports/links", handle_cors_preflight)
-        .options_async("/api/tags", handle_cors_preflight)
-        .options_async("/api/tags/:name", handle_cors_preflight)
-        .options_async("/api/fetch-title", handle_cors_preflight)
-        .options_async("/api/version", handle_cors_preflight)
-        .options_async("/api/orgs", handle_cors_preflight)
-        .options_async("/api/orgs/:id", handle_cors_preflight)
-        .options_async("/api/orgs/:id/members/:user_id", handle_cors_preflight)
-        .options_async("/api/orgs/:id/invitations", handle_cors_preflight)
-        .options_async(
-            "/api/orgs/:id/invitations/:invitation_id",
-            handle_cors_preflight,
-        )
-        .options_async(
-            "/api/orgs/:id/invitations/:invitation_id/resend",
-            handle_cors_preflight,
-        )
-        .options_async("/api/orgs/:id/settings", handle_cors_preflight)
-        .options_async("/api/orgs/:id/logo", handle_cors_preflight)
-        .options_async("/api/auth/switch-org", handle_cors_preflight)
-        .options_async("/api/invite/:token", handle_cors_preflight)
-        .options_async("/api/invite/:token/accept", handle_cors_preflight)
-        .options_async("/api/billing/status", handle_cors_preflight)
-        .options_async("/api/billing/checkout", handle_cors_preflight)
-        .options_async("/api/billing/pricing", handle_cors_preflight)
-        .options_async("/api/billing/webhook", handle_cors_preflight)
-        .options_async("/api/billing/portal", handle_cors_preflight)
-        .options_async("/api/admin/cron/trigger-downgrade", handle_cors_preflight)
-        .options_async("/api/settings", handle_cors_preflight)
-        .options_async("/api/settings/api-keys", handle_cors_preflight)
-        .options_async("/api/settings/api-keys/:id", handle_cors_preflight)
-        .options_async("/api/admin/api-keys", handle_cors_preflight)
-        .options_async("/api/admin/api-keys/:id", handle_cors_preflight)
-        .options_async("/api/admin/api-keys/:id/delete", handle_cors_preflight)
-        .options_async("/api/admin/api-keys/:id/restore", handle_cors_preflight)
-        .options_async("/api/admin/api-keys/:id/reactivate", handle_cors_preflight)
-        .options_async("/api/analytics/org", handle_cors_preflight)
         // Auth routes (public)
         .get_async("/api/auth/providers", router::handle_list_auth_providers)
         .get_async("/api/auth/github", router::handle_github_login)

--- a/src/repositories/tag_repository.rs
+++ b/src/repositories/tag_repository.rs
@@ -1,6 +1,7 @@
 /// Tag repository - Data access for tags
 ///
 /// Handles all database operations related to tags.
+use crate::utils::normalize_tag;
 use worker::d1::D1Database;
 use worker::*;
 
@@ -9,17 +10,6 @@ use worker::*;
 pub struct OrgTag {
     pub name: String,
     pub count: i64,
-}
-
-/// Normalize a tag name: trim whitespace, collapse internal spaces, max 50 chars.
-/// Returns None if the result is empty or too long.
-pub fn normalize_tag(tag: &str) -> Option<String> {
-    let normalized: String = tag.split_whitespace().collect::<Vec<&str>>().join(" ");
-    if normalized.is_empty() || normalized.len() > 50 {
-        None
-    } else {
-        Some(normalized)
-    }
 }
 
 /// Validate and normalize a list of tags. Returns an error if any tag is invalid.

--- a/src/services/tag_service.rs
+++ b/src/services/tag_service.rs
@@ -2,7 +2,8 @@
 ///
 /// Handles tag validation, business rules, and orchestrates the tag repository.
 use crate::repositories::TagRepository;
-use crate::repositories::tag_repository::{OrgTag, normalize_tag};
+use crate::repositories::tag_repository::OrgTag;
+use crate::utils::normalize_tag;
 use worker::d1::D1Database;
 use worker::*;
 

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -1,0 +1,71 @@
+/// Application-level error type for API handlers.
+///
+/// `AppError` provides a single error type that all API handlers return.
+/// It converts cleanly to HTTP responses, eliminating the `match auth::... { Err(e) => return Ok(e.into_response()) }`
+/// boilerplate. Handlers that return `Result<Response, AppError>` can use `?` throughout.
+///
+/// # Usage in handlers
+///
+/// ```rust
+/// pub async fn handle_example(req: Request, ctx: RouteContext<()>) -> Result<Response, AppError> {
+///     let user_ctx = auth::authenticate_request(&req, &ctx).await?;
+///     // ...
+///     Ok(Response::from_json(&data)?)
+/// }
+/// ```
+///
+/// The router calls `handler(...).await.unwrap_or_else(|e| e.into_response())` to convert
+/// `AppError` back into a `worker::Response`.
+use crate::auth::middleware::AuthError;
+use worker::Response;
+
+/// Unified error type for all API handler layers.
+#[derive(Debug)]
+pub enum AppError {
+    /// 401 Unauthorized — missing or invalid credentials
+    Unauthorized(String),
+    /// 403 Forbidden — authenticated but not allowed
+    Forbidden(String),
+    /// 400 Bad Request — invalid input
+    BadRequest(String),
+    /// 404 Not Found
+    NotFound(String),
+    /// 409 Conflict — duplicate or state conflict
+    Conflict(String),
+    /// 500 Internal Server Error
+    Internal(String),
+    /// 403 with tier upgrade message
+    TierLimitReached(String),
+}
+
+impl AppError {
+    /// Convert into an HTTP `Response`. Always succeeds.
+    pub fn into_response(self) -> Response {
+        let (msg, status) = match self {
+            AppError::Unauthorized(m) => (m, 401u16),
+            AppError::Forbidden(m) => (m, 403),
+            AppError::BadRequest(m) => (m, 400),
+            AppError::NotFound(m) => (m, 404),
+            AppError::Conflict(m) => (m, 409),
+            AppError::Internal(m) => (m, 500),
+            AppError::TierLimitReached(m) => (m, 403),
+        };
+        Response::error(msg, status).unwrap_or_else(|_| Response::error("Error", status).unwrap())
+    }
+}
+
+impl From<AuthError> for AppError {
+    fn from(e: AuthError) -> Self {
+        match e {
+            AuthError::Unauthorized(m) => AppError::Unauthorized(m),
+            AuthError::Forbidden(m) => AppError::Forbidden(m),
+            AuthError::InternalError(m) => AppError::Internal(m),
+        }
+    }
+}
+
+impl From<worker::Error> for AppError {
+    fn from(e: worker::Error) -> Self {
+        AppError::Internal(e.to_string())
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,12 +1,16 @@
 pub mod crypto;
 pub mod email;
+pub mod errors;
+pub mod query_params;
 pub mod short_code;
 pub mod time;
 pub mod url_normalization;
 pub mod validation;
 
 pub use crypto::{secure_compare, verify_polar_webhook_signature};
+pub use errors::AppError;
+pub use query_params::QueryParams;
 pub use short_code::{generate_short_code, generate_short_code_with_length};
 pub use time::now_timestamp;
 pub use url_normalization::normalize_url_for_blacklist;
-pub use validation::{validate_short_code, validate_url};
+pub use validation::{normalize_tag, validate_short_code, validate_url};

--- a/src/utils/query_params.rs
+++ b/src/utils/query_params.rs
@@ -1,0 +1,53 @@
+/// Query parameter parsing helpers.
+///
+/// # Example
+///
+/// ```rust
+/// let params = QueryParams::from_request(&req)?;
+/// let page: u32 = params.get_u32("page").unwrap_or(1);
+/// let limit: u32 = params.get_u32("limit").unwrap_or(50).min(100);
+/// let search: Option<String> = params.get("search");
+/// ```
+use std::collections::HashMap;
+use worker::Request;
+
+/// Parsed query string parameters from a request URL.
+pub struct QueryParams(HashMap<String, String>);
+
+impl QueryParams {
+    /// Parse query parameters from a `Request`.
+    /// Returns an empty map when there is no query string.
+    pub fn from_request(req: &Request) -> worker::Result<Self> {
+        let url = req.url()?;
+        let map = url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        Ok(Self(map))
+    }
+
+    /// Get a raw string value for a key.
+    pub fn get(&self, key: &str) -> Option<String> {
+        self.0.get(key).cloned()
+    }
+
+    /// Get a value parsed as `u32`. Returns `None` if the key is absent or
+    /// the value cannot be parsed.
+    pub fn get_u32(&self, key: &str) -> Option<u32> {
+        self.0.get(key)?.parse().ok()
+    }
+
+    /// Get a value parsed as `i64`. Returns `None` if the key is absent or
+    /// the value cannot be parsed.
+    pub fn get_i64(&self, key: &str) -> Option<i64> {
+        self.0.get(key)?.parse().ok()
+    }
+
+    /// Returns `true` if the key is present with a truthy value (`"1"`, `"true"`, `"yes"`).
+    pub fn flag(&self, key: &str) -> bool {
+        matches!(
+            self.0.get(key).map(|s| s.as_str()),
+            Some("1") | Some("true") | Some("yes")
+        )
+    }
+}

--- a/src/utils/validation.rs
+++ b/src/utils/validation.rs
@@ -37,6 +37,17 @@ const RESERVED_CODES: &[&str] = &[
     "index",
 ];
 
+/// Normalize a tag name: trim whitespace, collapse internal spaces, max 50 chars.
+/// Returns `None` if the result is empty or exceeds the length limit.
+pub fn normalize_tag(tag: &str) -> Option<String> {
+    let normalized: String = tag.split_whitespace().collect::<Vec<&str>>().join(" ");
+    if normalized.is_empty() || normalized.len() > 50 {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
 /// Validate a destination URL
 /// Must be http or https scheme
 pub fn validate_url(url_str: &str) -> Result<String, String> {

--- a/tests/tags_test.rs
+++ b/tests/tags_test.rs
@@ -508,6 +508,155 @@ async fn test_get_org_tags_returns_counts() {
     assert_eq!(count, 2, "Tag count should be 2");
 }
 
+// ─── DELETE /api/tags/:name ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_delete_org_tag_requires_auth() {
+    let client = test_client();
+    let response = client
+        .delete(format!("{}/api/tags/some-tag", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_delete_org_tag_removes_from_all_links() {
+    let client = authenticated_client();
+    let unique_tag = format!("deltag-{}", unique_short_code("dt"));
+    let code1 = unique_short_code("dt1");
+    let code2 = unique_short_code("dt2");
+
+    // Create two links sharing the unique tag
+    for code in [&code1, &code2] {
+        let r = client
+            .post(format!("{}/api/links", BASE_URL))
+            .json(&json!({
+                "destination_url": "https://example.com/del-tag-test",
+                "short_code": code,
+                "tags": [unique_tag.clone(), "other-tag"]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+    }
+
+    // Delete the unique tag via DELETE /api/tags/:name
+    let del_resp = client
+        .delete(format!(
+            "{}/api/tags/{}",
+            BASE_URL,
+            urlencoding::encode(&unique_tag)
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(del_resp.status(), StatusCode::NO_CONTENT);
+
+    // The tag should no longer appear in the org tag list
+    let tags_resp = client
+        .get(format!("{}/api/tags", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(tags_resp.status(), StatusCode::OK);
+    let tags: serde_json::Value = tags_resp.json().await.unwrap();
+    let found = tags
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|t| t["name"].as_str() == Some(unique_tag.as_str()));
+    assert!(!found, "Deleted tag should no longer appear in org tags");
+}
+
+#[tokio::test]
+async fn test_delete_org_tag_returns_404_for_nonexistent() {
+    let client = authenticated_client();
+    let response = client
+        .delete(format!("{}/api/tags/nonexistent-tag-xyz-999", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ─── PATCH /api/tags/:name ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_rename_org_tag_requires_auth() {
+    let client = test_client();
+    let response = client
+        .patch(format!("{}/api/tags/some-tag", BASE_URL))
+        .json(&json!({ "new_name": "renamed-tag" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_rename_org_tag_renames_across_links() {
+    let client = authenticated_client();
+    let old_tag = format!("rename-old-{}", unique_short_code("ro"));
+    let new_tag = format!("rename-new-{}", unique_short_code("rn"));
+    let code = unique_short_code("rnt");
+
+    // Create a link with the old tag
+    let create_resp = client
+        .post(format!("{}/api/links", BASE_URL))
+        .json(&json!({
+            "destination_url": "https://example.com/rename-tag-test",
+            "short_code": code,
+            "tags": [old_tag.clone()]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_resp.status(), StatusCode::OK);
+
+    // Rename the tag via PATCH /api/tags/:name
+    let rename_resp = client
+        .patch(format!(
+            "{}/api/tags/{}",
+            BASE_URL,
+            urlencoding::encode(&old_tag)
+        ))
+        .json(&json!({ "new_name": new_tag.clone() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(rename_resp.status(), StatusCode::OK);
+    let tags: serde_json::Value = rename_resp.json().await.unwrap();
+    let tags_arr = tags.as_array().unwrap();
+    // Old tag gone, new tag present
+    assert!(
+        !tags_arr
+            .iter()
+            .any(|t| t["name"].as_str() == Some(old_tag.as_str())),
+        "Old tag should no longer appear after rename"
+    );
+    assert!(
+        tags_arr
+            .iter()
+            .any(|t| t["name"].as_str() == Some(new_tag.as_str())),
+        "New tag should appear after rename"
+    );
+}
+
+#[tokio::test]
+async fn test_rename_org_tag_rejects_missing_new_name() {
+    let client = authenticated_client();
+    let response = client
+        .patch(format!("{}/api/tags/any-tag", BASE_URL))
+        .json(&json!({ "wrong_field": "value" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
 // ─── Tag filter combined with search ─────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
- Replace ~85 individual .options_async() registrations with single OPTIONS handler in lib.rs
- Add utils/errors.rs with AppError enum (Unauthorized, Forbidden, BadRequest, NotFound, Conflict, Internal, TierLimitReached)
- Retro-fit api/tags/ handlers (list, delete, rename) to use AppError with inner() pattern
- Move normalize_tag() to utils/validation.rs (canonical home), update callers
- Add utils/query_params.rs for query string parsing helper
- Add integration tests for DELETE /api/tags/:name and PATCH /api/tags/:name (auth, happy path, error cases)

Closes: #262 