### PR TITLE
refactor: extract user-facing CRUD to service/repository layers

### DIFF
--- a/src/api/keys/mod.rs
+++ b/src/api/keys/mod.rs
@@ -1,0 +1,3 @@
+pub mod user;
+
+pub use user::*;

--- a/src/api/keys/user.rs
+++ b/src/api/keys/user.rs
@@ -1,8 +1,6 @@
 use crate::auth::authenticate_request;
-use crate::utils::{generate_short_code_with_length, now_timestamp};
-use hex; // Add hex crate for formatting
+use crate::services::ApiKeyService;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use utoipa::ToSchema;
 use worker::*;
 
@@ -66,80 +64,31 @@ pub async fn handle_create_api_key(mut req: Request, ctx: RouteContext<()>) -> R
     }
 
     let db = ctx.env.get_binding::<worker::d1::D1Database>("rushomon")?;
-    let now = now_timestamp();
 
-    // Check if user's tier allows API keys
-    let org = match crate::db::get_org_by_id(&db, &user_ctx.org_id).await {
-        Ok(Some(org)) => org,
-        Ok(None) => return Response::error("Organization not found", 404),
-        Err(_) => return Response::error("Failed to validate organization", 500),
-    };
-
-    let tier = if let Some(ref billing_account_id) = org.billing_account_id {
-        match crate::db::get_billing_account(&db, billing_account_id).await {
-            Ok(Some(billing_account)) => crate::models::Tier::from_str_value(&billing_account.tier)
-                .unwrap_or(crate::models::Tier::Free),
-            Ok(None) => crate::models::Tier::Free,
-            Err(_) => return Response::error("Failed to validate billing account", 500),
+    let (key_id, raw_token, hint, created_at, expires_at) = match ApiKeyService::new()
+        .create(
+            &db,
+            &user_ctx.user_id,
+            &user_ctx.org_id,
+            &body.name,
+            body.expires_in_days,
+        )
+        .await
+    {
+        Ok(result) => result,
+        Err(worker::Error::RustError(msg)) if msg.contains("Upgrade to Pro") => {
+            return Response::error(msg, 403);
         }
-    } else {
-        crate::models::Tier::Free
+        Err(e) => return Err(e),
     };
-
-    if !tier.limits().allow_api_keys {
-        return Response::error(
-            "API keys are not available on your current plan. Upgrade to Pro or higher to use API keys.",
-            403,
-        );
-    }
-
-    // Calculate expiration if provided
-    let expires_at = body.expires_in_days.map(|days| now + (days * 24 * 60 * 60));
-
-    // Generate the raw token (prefix + 32 random chars)
-    let raw_token = format!("ro_pat_{}", generate_short_code_with_length(32));
-
-    // Generate the hint (prefix + last 4 chars)
-    let hint = format!("ro_pat_...{}", &raw_token[raw_token.len() - 4..]);
-
-    // Hash the token for storage
-    let mut hasher = Sha256::new();
-    hasher.update(raw_token.as_bytes());
-    let key_hash = hex::encode(hasher.finalize());
-
-    let key_id = uuid::Uuid::new_v4().to_string();
-
-    // Store in database
-    let stmt = db.prepare(
-        "INSERT INTO api_keys (id, user_id, org_id, name, key_hash, hint, created_at, expires_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-    );
-
-    let user_id_for_db = user_ctx.user_id.clone();
-    let org_id_for_db = user_ctx.org_id.clone();
-
-    stmt.bind(&[
-        key_id.clone().into(),
-        user_id_for_db.into(),
-        org_id_for_db.into(),
-        body.name.clone().into(),
-        key_hash.clone().into(),
-        hint.clone().into(),
-        (now as f64).into(),
-        expires_at
-            .map(|t| (t as f64).into())
-            .unwrap_or(worker::wasm_bindgen::JsValue::NULL),
-    ])?
-    .run()
-    .await?;
 
     // Return the raw token EXACTLY ONCE
     Response::from_json(&serde_json::json!({
         "id": key_id,
         "name": body.name,
         "hint": hint,
-        "raw_token": raw_token, // The UI must instruct the user to copy this immediately
-        "created_at": now,
+        "raw_token": raw_token,
+        "created_at": created_at,
         "expires_at": expires_at
     }))
 }
@@ -166,17 +115,7 @@ pub async fn handle_list_api_keys(req: Request, ctx: RouteContext<()>) -> Result
     };
 
     let db = ctx.env.get_binding::<worker::d1::D1Database>("rushomon")?;
-
-    let stmt = db.prepare(
-        "SELECT id, name, hint, created_at, last_used_at, expires_at
-         FROM api_keys
-         WHERE user_id = ?1 AND status = 'active'
-         ORDER BY created_at DESC",
-    );
-
-    let results = stmt.bind(&[user_ctx.user_id.into()])?.all().await?;
-    let keys = results.results::<serde_json::Value>()?;
-
+    let keys = ApiKeyService::new().list(&db, &user_ctx.user_id).await?;
     Response::from_json(&keys)
 }
 
@@ -210,20 +149,9 @@ pub async fn handle_revoke_api_key(req: Request, ctx: RouteContext<()>) -> Resul
         .ok_or_else(|| Error::RustError("Missing ID".to_string()))?;
     let db = ctx.env.get_binding::<worker::d1::D1Database>("rushomon")?;
 
-    // Soft delete - set status to 'deleted'
-    let timestamp = crate::utils::time::now_timestamp();
-    let stmt = db.prepare(
-        "UPDATE api_keys SET status = 'deleted', updated_at = ?1, updated_by = ?2
-         WHERE id = ?3 AND user_id = ?4 AND status = 'active'",
-    );
-    stmt.bind(&[
-        (timestamp as f64).into(),
-        user_ctx.user_id.clone().into(),
-        key_id.into(),
-        user_ctx.user_id.into(),
-    ])?
-    .run()
-    .await?;
+    ApiKeyService::new()
+        .revoke(&db, key_id, &user_ctx.user_id)
+        .await?;
 
     Ok(Response::empty()?.with_status(204))
 }

--- a/src/repositories/api_key_repository.rs
+++ b/src/repositories/api_key_repository.rs
@@ -1,11 +1,24 @@
-/// API Key Repository (admin operations)
+/// API Key Repository
 ///
-/// Provides admin-level data access for the `api_keys` table.
-/// User-facing API key queries remain in `db/queries.rs` for now.
+/// Provides data access for the `api_keys` table covering both admin and
+/// user-facing operations.
 use crate::db::queries::AdminApiKeyRecord;
 use crate::utils::now_timestamp;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use worker::Result;
 use worker::d1::D1Database;
+
+/// A user-visible API key record (no key_hash, no raw token).
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ApiKeyRecord {
+    pub id: String,
+    pub name: String,
+    pub hint: String,
+    pub created_at: i64,
+    pub last_used_at: Option<i64>,
+    pub expires_at: Option<i64>,
+}
 
 pub struct ApiKeyRepository;
 
@@ -204,6 +217,81 @@ impl ApiKeyRepository {
             (now_timestamp() as f64).into(),
             admin_user_id.into(),
             key_id.into(),
+        ])?
+        .run()
+        .await?;
+        Ok(())
+    }
+
+    /// Insert a new API key for a user. The `key_hash` is a SHA-256 hex string.
+    /// Returns the generated key ID.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_for_user(
+        &self,
+        db: &D1Database,
+        id: &str,
+        user_id: &str,
+        org_id: &str,
+        name: &str,
+        key_hash: &str,
+        hint: &str,
+        created_at: i64,
+        expires_at: Option<i64>,
+    ) -> Result<()> {
+        db.prepare(
+            "INSERT INTO api_keys (id, user_id, org_id, name, key_hash, hint, created_at, expires_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        )
+        .bind(&[
+            id.into(),
+            user_id.into(),
+            org_id.into(),
+            name.into(),
+            key_hash.into(),
+            hint.into(),
+            (created_at as f64).into(),
+            expires_at
+                .map(|t| (t as f64).into())
+                .unwrap_or(worker::wasm_bindgen::JsValue::NULL),
+        ])?
+        .run()
+        .await?;
+        Ok(())
+    }
+
+    /// List active API keys for a specific user (no raw token returned).
+    pub async fn list_for_user(&self, db: &D1Database, user_id: &str) -> Result<Vec<ApiKeyRecord>> {
+        let results = db
+            .prepare(
+                "SELECT id, name, hint, created_at, last_used_at, expires_at
+                 FROM api_keys
+                 WHERE user_id = ?1 AND status = 'active'
+                 ORDER BY created_at DESC",
+            )
+            .bind(&[user_id.into()])?
+            .all()
+            .await?;
+        results.results::<ApiKeyRecord>()
+    }
+
+    /// Soft-delete a key owned by the given user (status: active → deleted).
+    /// Scoped to `user_id` so users cannot revoke other users' keys.
+    pub async fn revoke_for_user(
+        &self,
+        db: &D1Database,
+        key_id: &str,
+        user_id: &str,
+    ) -> Result<()> {
+        let now = now_timestamp();
+        db.prepare(
+            "UPDATE api_keys SET status = 'deleted', updated_at = ?1, updated_by = ?2
+             WHERE id = ?3 AND user_id = ?4 AND status = 'active'",
+        )
+        .bind(&[
+            (now as f64).into(),
+            user_id.into(),
+            key_id.into(),
+            user_id.into(),
         ])?
         .run()
         .await?;

--- a/src/repositories/billing_repository.rs
+++ b/src/repositories/billing_repository.rs
@@ -1,8 +1,7 @@
 /// Billing Repository
 ///
 /// Data access layer for billing accounts, subscriptions, and webhook records.
-/// This is the first population of this repository — additional functions will be
-/// added when the Billing domain (Step 14) and Organization domain (Step 12) are extracted.
+use crate::models::BillingAccount;
 use crate::utils::now_timestamp;
 use worker::Result;
 use worker::d1::D1Database;
@@ -67,6 +66,24 @@ impl BillingRepository {
             .run()
             .await?;
         Ok(())
+    }
+
+    /// Get the billing account for the organization that contains the user.
+    /// Returns None if the organization has no billing account associated.
+    pub async fn get_billing_account_for_org(
+        &self,
+        db: &D1Database,
+        org_id: &str,
+    ) -> Result<Option<BillingAccount>> {
+        db.prepare(
+            "SELECT ba.id, ba.owner_user_id, ba.tier, ba.provider_customer_id, ba.created_at
+             FROM billing_accounts ba
+             JOIN organizations o ON o.billing_account_id = ba.id
+             WHERE o.id = ?1",
+        )
+        .bind(&[org_id.into()])?
+        .first::<BillingAccount>(None)
+        .await
     }
 
     /// Delete expired webhook records (for cleanup cron job).

--- a/src/services/api_key_service.rs
+++ b/src/services/api_key_service.rs
@@ -1,0 +1,89 @@
+/// API Key Service
+///
+/// Business logic for user-facing API key management:
+/// - Tier gating (Pro+ required)
+/// - Token generation and hashing
+/// - Ownership-scoped revocation
+use crate::models::Tier;
+use crate::repositories::api_key_repository::ApiKeyRecord;
+use crate::repositories::{ApiKeyRepository, BillingRepository};
+use crate::utils::{generate_short_code_with_length, now_timestamp};
+use hex;
+use sha2::{Digest, Sha256};
+use worker::Result;
+use worker::d1::D1Database;
+
+pub struct ApiKeyService;
+
+impl ApiKeyService {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Create a new API key for the given user/org.
+    ///
+    /// Performs the tier check, generates the token + hash, and persists the record.
+    /// Returns `(key_id, raw_token, hint, created_at, expires_at)`.
+    /// The raw token is shown exactly once — callers must surface it to the user immediately.
+    pub async fn create(
+        &self,
+        db: &D1Database,
+        user_id: &str,
+        org_id: &str,
+        name: &str,
+        expires_in_days: Option<i64>,
+    ) -> Result<(String, String, String, i64, Option<i64>)> {
+        // --- Tier gate ---
+        let billing_repo = BillingRepository::new();
+        let tier = match billing_repo.get_billing_account_for_org(db, org_id).await? {
+            Some(ba) => Tier::from_str_value(&ba.tier).unwrap_or(Tier::Free),
+            None => Tier::Free,
+        };
+
+        if !tier.limits().allow_api_keys {
+            return Err(worker::Error::RustError(
+                "API keys are not available on your current plan. Upgrade to Pro or higher to use API keys.".to_string(),
+            ));
+        }
+
+        // --- Generate token ---
+        let now = now_timestamp();
+        let expires_at = expires_in_days.map(|days| now + (days * 24 * 60 * 60));
+        let raw_token = format!("ro_pat_{}", generate_short_code_with_length(32));
+        let hint = format!("ro_pat_...{}", &raw_token[raw_token.len() - 4..]);
+
+        // Hash for storage
+        let mut hasher = Sha256::new();
+        hasher.update(raw_token.as_bytes());
+        let key_hash = hex::encode(hasher.finalize());
+
+        let key_id = uuid::Uuid::new_v4().to_string();
+
+        // --- Persist ---
+        ApiKeyRepository::new()
+            .create_for_user(
+                db, &key_id, user_id, org_id, name, &key_hash, &hint, now, expires_at,
+            )
+            .await?;
+
+        Ok((key_id, raw_token, hint, now, expires_at))
+    }
+
+    /// List active API keys for the given user.
+    pub async fn list(&self, db: &D1Database, user_id: &str) -> Result<Vec<ApiKeyRecord>> {
+        ApiKeyRepository::new().list_for_user(db, user_id).await
+    }
+
+    /// Revoke an API key that must be owned by `user_id`.
+    pub async fn revoke(&self, db: &D1Database, key_id: &str, user_id: &str) -> Result<()> {
+        ApiKeyRepository::new()
+            .revoke_for_user(db, key_id, user_id)
+            .await
+    }
+}
+
+impl Default for ApiKeyService {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -14,11 +14,13 @@
 
 // Add service modules here as they are created:
 pub mod analytics_service;
+pub mod api_key_service;
 pub mod auth_service;
 pub mod product_service;
 pub mod settings_service;
 pub mod subscription_service;
 pub mod tag_service;
+pub use api_key_service::ApiKeyService;
 pub use auth_service::AuthService;
 pub use product_service::ProductService;
 pub use settings_service::SettingsService;


### PR DESCRIPTION
- Add ApiKeyRecord struct to api_key_repository.rs for user-visible key data
- Add create_for_user, list_for_user, revoke_for_user to ApiKeyRepository
- Add get_billing_account_for_org to BillingRepository
- Create services/api_key_service.rs with create(), list(), revoke()
- Move api/keys.rs → api/keys/user.rs with mod.rs re-exporting via pub use user::*
- Simplify api/keys/user.rs handlers to delegate entirely to ApiKeyService

Closes #301 