### PR TITLE
refactor: centralize duplicate helper functions

### DIFF
--- a/src/api/auth/oauth.rs
+++ b/src/api/auth/oauth.rs
@@ -4,36 +4,10 @@
 /// GET /api/auth/google    - Initiate Google OAuth
 /// GET /api/auth/callback  - OAuth provider callback
 use crate::auth;
-use crate::middleware::{RateLimitConfig, RateLimiter};
+use crate::middleware::{RateLimitConfig, RateLimiter, is_kv_rate_limiting_enabled};
 use crate::services::OAuthService;
+use crate::utils::{get_client_ip, get_frontend_url, hash_ip};
 use worker::*;
-
-/// Extract client IP from Cloudflare headers
-fn get_client_ip(req: &Request) -> String {
-    if let Ok(Some(ip)) = req.headers().get("CF-Connecting-IP") {
-        return ip;
-    }
-    // Fallback to X-Forwarded-For
-    if let Ok(Some(forwarded)) = req.headers().get("X-Forwarded-For")
-        && let Some(ip) = forwarded.split(',').next()
-    {
-        return ip.trim().to_string();
-    }
-    // Fallback to X-Real-IP
-    if let Ok(Some(ip)) = req.headers().get("X-Real-IP") {
-        return ip;
-    }
-    "unknown".to_string()
-}
-
-/// Hash an IP address for logging to avoid storing raw IPs
-fn hash_ip(ip: &str) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
-    ip.hash(&mut hasher);
-    format!("{:x}", hasher.finish())
-}
 
 /// Helper function to extract query parameters
 fn extract_query_param(query: &str, name: &str) -> Result<String> {
@@ -50,13 +24,6 @@ fn extract_query_param(query: &str, name: &str) -> Result<String> {
             }
         })
         .ok_or_else(|| Error::RustError(format!("Missing {} parameter", name)))
-}
-
-/// Get frontend URL from environment
-fn get_frontend_url(env: &Env) -> String {
-    env.var("FRONTEND_URL")
-        .map(|v| v.to_string())
-        .unwrap_or_else(|_| "http://localhost:5173".to_string())
 }
 
 #[utoipa::path(
@@ -79,18 +46,11 @@ pub async fn handle_github_login(req: Request, ctx: RouteContext<()>) -> Result<
     let rate_limit_key = RateLimiter::ip_key("oauth", &client_ip);
     let rate_limit_config = RateLimitConfig::oauth();
 
-    // Check if KV rate limiting is enabled (default false)
-    let kv_rate_limiting_enabled = ctx
-        .env
-        .var("ENABLE_KV_RATE_LIMITING")
-        .map(|v| v.to_string() == "true")
-        .unwrap_or(false);
-
     if let Err(err) = RateLimiter::check(
         &kv,
         &rate_limit_key,
         &rate_limit_config,
-        kv_rate_limiting_enabled,
+        is_kv_rate_limiting_enabled(&ctx.env),
     )
     .await
     {
@@ -138,17 +98,11 @@ pub async fn handle_google_login(req: Request, ctx: RouteContext<()>) -> Result<
     let rate_limit_key = RateLimiter::ip_key("oauth", &client_ip);
     let rate_limit_config = RateLimitConfig::oauth();
 
-    let kv_rate_limiting_enabled = ctx
-        .env
-        .var("ENABLE_KV_RATE_LIMITING")
-        .map(|v| v.to_string() == "true")
-        .unwrap_or(false);
-
     if let Err(err) = RateLimiter::check(
         &kv,
         &rate_limit_key,
         &rate_limit_config,
-        kv_rate_limiting_enabled,
+        is_kv_rate_limiting_enabled(&ctx.env),
     )
     .await
     {
@@ -201,17 +155,11 @@ pub async fn handle_oauth_callback(req: Request, ctx: RouteContext<()>) -> Resul
     let rate_limit_key = RateLimiter::ip_key("oauth", &client_ip);
     let rate_limit_config = RateLimitConfig::oauth();
 
-    let kv_rate_limiting_enabled = ctx
-        .env
-        .var("ENABLE_KV_RATE_LIMITING")
-        .map(|v| v.to_string() == "true")
-        .unwrap_or(false);
-
     if let Err(err) = RateLimiter::check(
         &kv,
         &rate_limit_key,
         &rate_limit_config,
-        kv_rate_limiting_enabled,
+        is_kv_rate_limiting_enabled(&ctx.env),
     )
     .await
     {

--- a/src/api/auth/session.rs
+++ b/src/api/auth/session.rs
@@ -4,7 +4,7 @@
 /// POST /api/auth/refresh — refresh access token
 /// POST /api/auth/logout  — logout and clear cookies
 use crate::auth;
-use crate::middleware::{RateLimitConfig, RateLimiter};
+use crate::middleware::{RateLimitConfig, RateLimiter, is_kv_rate_limiting_enabled};
 use crate::services::AuthService;
 use crate::utils::AppError;
 use worker::d1::D1Database;
@@ -42,17 +42,11 @@ async fn inner_get_current_user(req: Request, ctx: RouteContext<()>) -> Result<R
     let rate_limit_key = RateLimiter::session_key("auth_check", &user_ctx.session_id);
     let rate_limit_config = RateLimitConfig::auth_check();
 
-    let kv_rate_limiting_enabled = ctx
-        .env
-        .var("ENABLE_KV_RATE_LIMITING")
-        .map(|v| v.to_string() == "true")
-        .unwrap_or(false);
-
     if let Err(err) = RateLimiter::check(
         &kv,
         &rate_limit_key,
         &rate_limit_config,
-        kv_rate_limiting_enabled,
+        is_kv_rate_limiting_enabled(&ctx.env),
     )
     .await
     {
@@ -133,17 +127,11 @@ pub async fn handle_token_refresh(req: Request, ctx: RouteContext<()>) -> Result
     let rate_limit_key = RateLimiter::session_key("token_refresh", &claims.session_id);
     let rate_limit_config = RateLimitConfig::token_refresh();
 
-    let kv_rate_limiting_enabled = ctx
-        .env
-        .var("ENABLE_KV_RATE_LIMITING")
-        .map(|v| v.to_string() == "true")
-        .unwrap_or(false);
-
     if let Err(err) = RateLimiter::check(
         &kv,
         &rate_limit_key,
         &rate_limit_config,
-        kv_rate_limiting_enabled,
+        is_kv_rate_limiting_enabled(&ctx.env),
     )
     .await
     {

--- a/src/api/billing/checkout.rs
+++ b/src/api/billing/checkout.rs
@@ -2,14 +2,9 @@ use crate::auth;
 use crate::billing::polar::polar_client_from_env;
 use crate::billing::provider::BillingProvider;
 use crate::repositories::{BillingRepository, OrgRepository, SettingsRepository};
+use crate::utils::get_frontend_url;
 use worker::d1::D1Database;
 use worker::*;
-
-fn get_frontend_url(env: &Env) -> String {
-    env.var("FRONTEND_URL")
-        .map(|v| v.to_string())
-        .unwrap_or_else(|_| "http://localhost:5173".to_string())
-}
 
 #[utoipa::path(
     post,

--- a/src/api/billing/portal.rs
+++ b/src/api/billing/portal.rs
@@ -1,14 +1,9 @@
 use crate::auth;
 use crate::billing::polar::polar_client_from_env;
 use crate::repositories::BillingRepository;
+use crate::utils::get_frontend_url;
 use worker::d1::D1Database;
 use worker::*;
-
-fn get_frontend_url(env: &Env) -> String {
-    env.var("FRONTEND_URL")
-        .map(|v| v.to_string())
-        .unwrap_or_else(|_| "http://localhost:5173".to_string())
-}
 
 #[utoipa::path(
     post,

--- a/src/api/links/create.rs
+++ b/src/api/links/create.rs
@@ -1,6 +1,6 @@
 use crate::auth;
 use crate::kv;
-use crate::middleware::{RateLimitConfig, RateLimiter};
+use crate::middleware::{RateLimitConfig, RateLimiter, is_kv_rate_limiting_enabled};
 use crate::models::link::{CreateLinkRequest, Link, LinkStatus};
 use crate::repositories::tag_repository::validate_and_normalize_tags;
 use crate::repositories::{LinkRepository, OrgRepository};
@@ -40,17 +40,11 @@ pub async fn handle_create_link(mut req: Request, ctx: RouteContext<()>) -> Resu
     let rate_limit_key = RateLimiter::user_key("create_link", user_id);
     let rate_limit_config = RateLimitConfig::link_creation();
 
-    let kv_rate_limiting_enabled = ctx
-        .env
-        .var("ENABLE_KV_RATE_LIMITING")
-        .map(|v| v.to_string() == "true")
-        .unwrap_or(false);
-
     if let Err(err) = RateLimiter::check(
         &kv,
         &rate_limit_key,
         &rate_limit_config,
-        kv_rate_limiting_enabled,
+        is_kv_rate_limiting_enabled(&ctx.env),
     )
     .await
     {

--- a/src/api/links/mod.rs
+++ b/src/api/links/mod.rs
@@ -18,5 +18,5 @@ pub use export::handle_export_links;
 pub use get::{handle_get_link, handle_get_link_by_code};
 pub use import::handle_import_links;
 pub use list::handle_list_links;
-pub use redirect::{get_frontend_url, handle_redirect, sync_link_mapping_from_link};
+pub use redirect::{handle_redirect, sync_link_mapping_from_link};
 pub use update::handle_update_link;

--- a/src/api/links/redirect.rs
+++ b/src/api/links/redirect.rs
@@ -1,52 +1,12 @@
 use crate::kv;
-use crate::middleware::{RateLimitConfig, RateLimiter};
+use crate::middleware::{RateLimitConfig, RateLimiter, is_kv_rate_limiting_enabled};
 use crate::models::{AnalyticsEvent, link::LinkStatus};
 use crate::repositories::LinkRepository;
-use crate::utils::now_timestamp;
+use crate::utils::{get_client_ip, get_frontend_url, hash_ip, now_timestamp};
 use std::future::Future;
 use std::pin::Pin;
 use worker::d1::D1Database;
 use worker::*;
-
-/// Get the frontend URL from environment, with localhost fallback for local dev
-pub fn get_frontend_url(env: &Env) -> String {
-    env.var("FRONTEND_URL")
-        .map(|v| v.to_string())
-        .unwrap_or_else(|_| "http://localhost:5173".to_string())
-}
-
-/// Extract client IP from Cloudflare headers
-fn get_client_ip(req: &Request) -> String {
-    // Try CF-Connecting-IP first (most reliable with Cloudflare)
-    if let Ok(Some(ip)) = req.headers().get("CF-Connecting-IP") {
-        return ip;
-    }
-
-    // Fallback to X-Forwarded-For
-    if let Ok(Some(forwarded)) = req.headers().get("X-Forwarded-For")
-        && let Some(ip) = forwarded.split(',').next()
-    {
-        // Take first IP in the list
-        return ip.trim().to_string();
-    }
-
-    // Fallback to X-Real-IP
-    if let Ok(Some(ip)) = req.headers().get("X-Real-IP") {
-        return ip;
-    }
-
-    // Last resort: use a placeholder (should never happen with Cloudflare)
-    "unknown".to_string()
-}
-
-/// Hash an IP address for logging to avoid storing raw IPs
-fn hash_ip(ip: &str) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
-    ip.hash(&mut hasher);
-    format!("{:x}", hasher.finish())
-}
 
 /// Result of a redirect operation, containing the response and optional deferred analytics work.
 pub struct RedirectResult {
@@ -78,17 +38,11 @@ pub async fn handle_redirect(
     let rate_limit_key = RateLimiter::ip_key("redirect", &client_ip);
     let rate_limit_config = RateLimitConfig::redirect();
 
-    let kv_rate_limiting_enabled = ctx
-        .env
-        .var("ENABLE_KV_RATE_LIMITING")
-        .map(|v| v.to_string() == "true")
-        .unwrap_or(false);
-
     if let Err(err) = RateLimiter::check(
         &kv,
         &rate_limit_key,
         &rate_limit_config,
-        kv_rate_limiting_enabled,
+        is_kv_rate_limiting_enabled(&ctx.env),
     )
     .await
     {

--- a/src/api/orgs/invitations.rs
+++ b/src/api/orgs/invitations.rs
@@ -5,13 +5,12 @@
 /// POST /api/orgs/{id}/invitations/{invitation_id}/resend - Resend invitation
 /// GET /api/invite/{token} - Get invite info (public)
 /// POST /api/invite/{token}/accept - Accept invite
-use crate::api::links::get_frontend_url;
 use crate::auth;
 use crate::models::Tier;
 use crate::repositories::{BillingRepository, OrgRepository, UserRepository};
 use crate::services::OrgService;
-use crate::utils::AppError;
 use crate::utils::email::send_org_invitation;
+use crate::utils::{AppError, get_frontend_url};
 use worker::d1::D1Database;
 use worker::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
         Some(port) => format!("{}:{}", url.host_str().unwrap_or(""), port),
         None => url.host_str().unwrap_or("").to_string(),
     };
-    let frontend_url_str = crate::api::links::get_frontend_url(&env);
+    let frontend_url_str = crate::utils::get_frontend_url(&env);
     let frontend_authority = Url::parse(&frontend_url_str)
         .ok()
         .map(|u| match u.port() {
@@ -587,7 +587,7 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
         .post_async("/api/fetch-title", crate::api::title_fetch::fetch_title)
         // Root redirect: redirect to frontend (e.g., rush.mn/ → rushomon.cc/)
         .get_async("/", |_req, ctx| async move {
-            let url = Url::parse(&crate::api::links::get_frontend_url(&ctx.env))?;
+            let url = Url::parse(&crate::utils::get_frontend_url(&ctx.env))?;
             Response::redirect_with_status(url, 301)
         })
         .run(req, env.clone())

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,3 +1,3 @@
 pub mod rate_limit;
 
-pub use rate_limit::{RateLimitConfig, RateLimiter};
+pub use rate_limit::{RateLimitConfig, RateLimiter, is_kv_rate_limiting_enabled};

--- a/src/middleware/rate_limit.rs
+++ b/src/middleware/rate_limit.rs
@@ -22,7 +22,17 @@
 ///
 /// See SECURITY.md for complete rate limiting roadmap.
 use serde::{Deserialize, Serialize};
+use worker::Env;
 use worker::kv::KvStore;
+
+/// Check whether KV-based rate limiting is enabled in the current environment.
+///
+/// Reads `ENABLE_KV_RATE_LIMITING` env var; returns `false` if absent or not `"true"`.
+pub fn is_kv_rate_limiting_enabled(env: &Env) -> bool {
+    env.var("ENABLE_KV_RATE_LIMITING")
+        .map(|v| v.to_string() == "true")
+        .unwrap_or(false)
+}
 
 /// Rate limit tracking data stored in KV
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Remove 4 local copies of get_frontend_url (oauth.rs, billing/checkout.rs, billing/portal.rs, redirect.rs) and 2 local copies of get_client_ip/hash_ip (oauth.rs, redirect.rs). All callers now use canonical implementations from crate::utils.

Centralize ENABLE_KV_RATE_LIMITING env check: move is_kv_rate_limiting_enabled to middleware/rate_limit.rs and replace 6 repeated inline env-var reads across oauth.rs, session.rs, create.rs, redirect.rs.

Update api/links/mod.rs to stop re-exporting get_frontend_url from redirect.rs. Update lib.rs and invitations.rs to use crate::utils::get_frontend_url directly.

Closes #308 