### PR TITLE
fix: fix admin dropdown menu overflow at viewport bottom

### DIFF
--- a/frontend/src/routes/admin/links/+page.svelte
+++ b/frontend/src/routes/admin/links/+page.svelte
@@ -113,8 +113,22 @@
       dropdownPosition = null;
     } else {
       activeDropdown = linkId;
+
+      // Estimate dropdown height (~5 items at ~33px each + padding ≈ 200px)
+      const estimatedMenuHeight = 200;
+      const spaceBelow = window.innerHeight - rect.bottom;
+
+      let top: number;
+      if (spaceBelow < estimatedMenuHeight && rect.top > estimatedMenuHeight) {
+        // Not enough space below, open upward
+        top = rect.top - estimatedMenuHeight - 4;
+      } else {
+        // Default: open below
+        top = rect.bottom + 4;
+      }
+
       dropdownPosition = {
-        top: rect.bottom + 4,
+        top,
         right: window.innerWidth - rect.right
       };
     }

--- a/frontend/src/routes/admin/users/+page.svelte
+++ b/frontend/src/routes/admin/users/+page.svelte
@@ -89,8 +89,22 @@
       dropdownPosition = null;
     } else {
       activeDropdown = userId;
+
+      // Estimate dropdown height (~5 items at ~33px each + padding ≈ 200px)
+      const estimatedMenuHeight = 200;
+      const spaceBelow = window.innerHeight - rect.bottom;
+
+      let top: number;
+      if (spaceBelow < estimatedMenuHeight && rect.top > estimatedMenuHeight) {
+        // Not enough space below, open upward
+        top = rect.top - estimatedMenuHeight - 4;
+      } else {
+        // Default: open below
+        top = rect.bottom + 4;
+      }
+
       dropdownPosition = {
-        top: rect.bottom + 4,
+        top,
         right: window.innerWidth - rect.right
       };
     }


### PR DESCRIPTION
Implement smart positioning for dropdown menus in admin pages to prevent overflow when opening near the bottom of the viewport. The menu now detects available space and flips to open upward when needed.

Changes:
- Added viewport-aware positioning to admin/links dropdown toggle
- Added viewport-aware positioning to admin/users dropdown toggle
- Menu opens upward when space below is insufficient
- Maintains default downward opening for normal cases

Closes #295 