### PR TITLE
feat: implement device-based routing for short links

### DIFF
--- a/docs/openapi/main.json
+++ b/docs/openapi/main.json
@@ -3479,6 +3479,30 @@
             "type": "string",
             "description": "HTTP redirect type: 301 (permanent) or 307 (temporary).\nDefault is 301, available on Pro+ plans.",
             "example": "301"
+          },
+          "ios_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "iOS-specific destination URL (Business tier feature).",
+            "example": "https://apps.apple.com/app/id123456789"
+          },
+          "android_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Android-specific destination URL (Business tier feature).",
+            "example": "https://play.google.com/store/apps/details?id=com.example"
+          },
+          "desktop_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Desktop-specific destination URL (Business tier feature).",
+            "example": "https://example.com/desktop-app"
           }
         },
         "additionalProperties": false
@@ -3604,6 +3628,30 @@
             "type": "string",
             "description": "HTTP redirect type: 301 (permanent) or 307 (temporary).\nDefault is 301 for SEO, 307 available on Pro+ plans.",
             "example": "301"
+          },
+          "ios_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "iOS-specific destination URL (Business tier feature).\nRedirects iPhone/iPad users to this URL instead of the default.",
+            "example": "https://apps.apple.com/app/id123456789"
+          },
+          "android_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Android-specific destination URL (Business tier feature).\nRedirects Android users to this URL instead of the default.",
+            "example": "https://play.google.com/store/apps/details?id=com.example"
+          },
+          "desktop_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Desktop-specific destination URL (Business tier feature).\nRedirects desktop users (Windows, macOS, Linux) to this URL instead of the default.",
+            "example": "https://example.com/desktop-app"
           }
         }
       },
@@ -4178,6 +4226,54 @@
             ],
             "description": "HTTP redirect type: 301 (permanent) or 307 (temporary).\nAvailable on Pro+ plans.",
             "example": "307"
+          },
+          "ios_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "iOS-specific destination URL (Business tier feature).\nSet to clear the iOS URL.",
+            "example": "https://apps.apple.com/app/id123456789"
+          },
+          "clear_ios_url": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Set to true to clear the iOS URL",
+            "example": false
+          },
+          "android_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Android-specific destination URL (Business tier feature).\nSet to clear the Android URL.",
+            "example": "https://play.google.com/store/apps/details?id=com.example"
+          },
+          "clear_android_url": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Set to true to clear the Android URL",
+            "example": false
+          },
+          "desktop_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Desktop-specific destination URL (Business tier feature).\nSet to clear the Desktop URL.",
+            "example": "https://example.com/desktop-app"
+          },
+          "clear_desktop_url": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Set to true to clear the Desktop URL",
+            "example": false
           }
         }
       },

--- a/frontend/src/lib/components/LinkModal.svelte
+++ b/frontend/src/lib/components/LinkModal.svelte
@@ -2,9 +2,11 @@
   import { linksApi, tagsApi } from "$lib/api/links";
   import TagInput from "$lib/components/TagInput.svelte";
   import type {
+    CreateLinkRequest,
     Link,
     LinkStatus,
     TagWithCount,
+    UpdateLinkRequest,
     UsageResponse,
     UtmParams
   } from "$lib/types/api";
@@ -243,20 +245,39 @@
         : undefined;
 
       // TODO: Review in the future if we can avoid this
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const linkData: any = {
-        destination_url: destinationUrl,
-        title: title || undefined,
-        tags: tags.length > 0 ? tags : [],
+
+      let linkData: CreateLinkRequest & Partial<UpdateLinkRequest> = {
+        destination_url: destinationUrl.trim(),
+        title: title.trim() || undefined,
+        tags: tags.length > 0 ? tags : undefined,
         utm_params: utmParams,
         forward_query_params: allowQueryForwarding
           ? forwardQueryParams
           : undefined,
-        redirect_type: redirectType,
-        ios_url: iosUrl.trim() || undefined,
-        android_url: androidUrl.trim() || undefined,
-        desktop_url: desktopUrl.trim() || undefined
+        redirect_type: redirectType
       };
+
+      // Handle device URLs: set, clear, or don't update
+      if (iosUrl.trim()) {
+        linkData.ios_url = iosUrl.trim();
+      } else if (link?.ios_url) {
+        // Send clear_ios_url flag to explicitly clear iOS URL
+        linkData.clear_ios_url = true;
+      }
+
+      if (androidUrl.trim()) {
+        linkData.android_url = androidUrl.trim();
+      } else if (link?.android_url) {
+        // Send clear_android_url flag to explicitly clear Android URL
+        linkData.clear_android_url = true;
+      }
+
+      if (desktopUrl.trim()) {
+        linkData.desktop_url = desktopUrl.trim();
+      } else if (link?.desktop_url) {
+        // Send clear_desktop_url flag to explicitly clear Desktop URL
+        linkData.clear_desktop_url = true;
+      }
 
       // Handle expiration: set, clear, or don't update
       if (expiresAt) {

--- a/frontend/src/lib/components/LinkModal.svelte
+++ b/frontend/src/lib/components/LinkModal.svelte
@@ -36,6 +36,9 @@
   const allowQueryForwarding = $derived(
     usage?.limits?.allow_query_forwarding ?? false
   );
+  const allowDeviceRouting = $derived(
+    usage?.limits?.allow_device_routing ?? false
+  );
   const isProOrAbove = $derived(allowUtmParameters || allowQueryForwarding);
   const modalTitle = $derived(
     isEditMode ? "Edit Link" : "Create New Short Link"
@@ -60,6 +63,12 @@
   let forwardQueryParams = $state(false);
   let redirectType = $state("301"); // Default to 301 for SEO
 
+  // Device routing state
+  let showDeviceRouting = $state(false);
+  let iosUrl = $state("");
+  let androidUrl = $state("");
+  let desktopUrl = $state("");
+
   const hasUtmParams = $derived(
     !!(
       utmSource.trim() ||
@@ -69,6 +78,10 @@
       utmContent.trim() ||
       utmRef.trim()
     )
+  );
+
+  const hasDeviceUrls = $derived(
+    !!(iosUrl.trim() || androidUrl.trim() || desktopUrl.trim())
   );
 
   function buildPreviewUrl(): string {
@@ -143,6 +156,10 @@
     forwardQueryParams = false;
     redirectType = "301"; // Reset to default
     showUtmBuilder = false;
+    iosUrl = "";
+    androidUrl = "";
+    desktopUrl = "";
+    showDeviceRouting = false;
     populatedLinkId = null;
   }
 
@@ -180,6 +197,11 @@
         showUtmBuilder = false; // Always start collapsed
         forwardQueryParams = link.forward_query_params ?? false;
         redirectType = link.redirect_type || "301"; // Load existing redirect type
+        // Device URLs
+        iosUrl = link.ios_url || "";
+        androidUrl = link.android_url || "";
+        desktopUrl = link.desktop_url || "";
+        showDeviceRouting = false; // Start collapsed
         error = "";
         populatedLinkId = link.id;
       } else if (!link) {
@@ -230,7 +252,10 @@
         forward_query_params: allowQueryForwarding
           ? forwardQueryParams
           : undefined,
-        redirect_type: redirectType
+        redirect_type: redirectType,
+        ios_url: iosUrl.trim() || undefined,
+        android_url: androidUrl.trim() || undefined,
+        desktop_url: desktopUrl.trim() || undefined
       };
 
       // Handle expiration: set, clear, or don't update
@@ -928,6 +953,184 @@
               UTM parameters &amp; query forwarding —
               <a href="/pricing" class="text-orange-600 hover:underline"
                 >Upgrade to Pro</a
+              ></span
+            >
+          </div>
+        {/if}
+
+        <!-- Device Routing Section -->
+        {#if allowDeviceRouting}
+          <div class="border border-gray-200 rounded-lg overflow-hidden">
+            <button
+              type="button"
+              class="w-full flex items-center justify-between px-4 py-3 bg-gray-50 hover:bg-gray-100 transition-colors text-sm font-medium text-gray-700"
+              onclick={() => (showDeviceRouting = !showDeviceRouting)}
+              disabled={loading}
+            >
+              <span class="flex items-center gap-2">
+                <svg
+                  class="w-4 h-4 text-purple-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+                  />
+                </svg>
+                Device-Based Routing
+                {#if hasDeviceUrls}
+                  <span
+                    class="bg-purple-100 text-purple-700 text-xs px-2 py-0.5 rounded-full"
+                    >active</span
+                  >
+                {/if}
+              </span>
+              <svg
+                class="w-4 h-4 text-gray-400 transition-transform {showDeviceRouting
+                  ? 'rotate-180'
+                  : ''}"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+            {#if showDeviceRouting}
+              <div class="p-4 space-y-4 border-t border-gray-200">
+                <p class="text-xs text-gray-500">
+                  Redirect visitors to different URLs based on their device
+                  type. Leave empty to use the default destination URL.
+                </p>
+
+                <!-- iOS URL -->
+                <div class="flex items-center gap-3">
+                  <div
+                    class="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-600"
+                      fill="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.21-1.96 1.07-3.11-1.05.05-2.31.71-3.06 1.64-.68.84-1.21 2.19-1.06 3.28 1.18.09 2.38-.59 3.05-1.81z"
+                      />
+                    </svg>
+                  </div>
+                  <label
+                    for="modal-ios-url"
+                    class="text-sm font-medium text-gray-700 w-20 flex-shrink-0"
+                    >iOS URL</label
+                  >
+                  <input
+                    type="url"
+                    id="modal-ios-url"
+                    bind:value={iosUrl}
+                    placeholder="https://apps.apple.com/..."
+                    disabled={loading}
+                    class="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:bg-gray-100"
+                  />
+                </div>
+
+                <!-- Android URL -->
+                <div class="flex items-center gap-3">
+                  <div
+                    class="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0"
+                  >
+                    <svg
+                      class="w-4 h-4 text-green-600"
+                      fill="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M17.523 15.3414c-.5511 0-.9993-.4486-.9993-.9997s.4482-.9993.9993-.9993c.5511 0 .9993.4482.9993.9993.0001.5511-.4482.9997-.9993.9997m-11.046 0c-.5511 0-.9993-.4486-.9993-.9997s.4482-.9993.9993-.9993c.5511 0 .9993.4482.9993.9993 0 .5511-.4482.9997-.9993.9997m11.4045-6.02l1.9973-3.4592a.416.416 0 00-.1521-.5676.416.416 0 00-.5676.1521l-2.0225 3.503C15.5902 8.4797 13.8535 8.178 12 8.178c-1.8535 0-3.5902.3017-5.1367.8494L4.8408 5.5244a.416.416 0 00-.5676-.1521.416.416 0 00-.1521.5676l1.9973 3.4592C2.6889 11.1867.3432 14.6589.3432 18.6617h23.3136c0-4.0028-2.3457-7.475-5.775-9.3403"
+                      />
+                    </svg>
+                  </div>
+                  <label
+                    for="modal-android-url"
+                    class="text-sm font-medium text-gray-700 w-20 flex-shrink-0"
+                    >Android URL</label
+                  >
+                  <input
+                    type="url"
+                    id="modal-android-url"
+                    bind:value={androidUrl}
+                    placeholder="https://play.google.com/..."
+                    disabled={loading}
+                    class="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:bg-gray-100"
+                  />
+                </div>
+
+                <!-- Desktop URL -->
+                <div class="flex items-center gap-3">
+                  <div
+                    class="w-8 h-8 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-600"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                      />
+                    </svg>
+                  </div>
+                  <label
+                    for="modal-desktop-url"
+                    class="text-sm font-medium text-gray-700 w-20 flex-shrink-0"
+                    >Desktop URL</label
+                  >
+                  <input
+                    type="url"
+                    id="modal-desktop-url"
+                    bind:value={desktopUrl}
+                    placeholder="https://example.com/desktop-version"
+                    disabled={loading}
+                    class="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:bg-gray-100"
+                  />
+                </div>
+              </div>
+            {/if}
+          </div>
+        {:else}
+          <!-- Device routing upsell for lower tiers -->
+          <div
+            class="flex items-center gap-2 p-3 bg-gray-50 border border-dashed border-gray-300 rounded-lg text-sm text-gray-500"
+          >
+            <svg
+              class="w-4 h-4 text-purple-500 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+              />
+            </svg>
+            <span
+              ><strong class="text-gray-700">Business feature:</strong>
+              Device-based routing —
+              <a href="/pricing" class="text-orange-600 hover:underline"
+                >Upgrade to Business</a
               ></span
             >
           </div>

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -42,6 +42,9 @@ export interface Link {
   utm_params?: UtmParams | null;
   forward_query_params?: boolean | null;
   redirect_type: string; // "301" or "307"
+  ios_url?: string | null;
+  android_url?: string | null;
+  desktop_url?: string | null;
 }
 
 export interface TagWithCount {
@@ -58,6 +61,9 @@ export interface CreateLinkRequest {
   utm_params?: UtmParams;
   forward_query_params?: boolean;
   redirect_type: string; // "301" or "307" - required field with default "301"
+  ios_url?: string;
+  android_url?: string;
+  desktop_url?: string;
 }
 
 export interface UpdateLinkRequest {
@@ -70,6 +76,12 @@ export interface UpdateLinkRequest {
   utm_params?: UtmParams;
   forward_query_params?: boolean;
   redirect_type?: string; // "301" or "307"
+  ios_url?: string;
+  android_url?: string;
+  desktop_url?: string;
+  clear_ios_url?: boolean;
+  clear_android_url?: boolean;
+  clear_desktop_url?: boolean;
 }
 
 export interface OrgSettings {
@@ -161,6 +173,7 @@ export interface UsageResponse {
     allow_custom_short_code: boolean;
     allow_utm_parameters: boolean;
     allow_query_forwarding: boolean;
+    allow_device_routing: boolean;
     max_tags: number | null;
   };
   usage: {

--- a/migrations/0029_device_routing.sql
+++ b/migrations/0029_device_routing.sql
@@ -1,0 +1,5 @@
+-- Device-based routing URLs (Business tier feature)
+-- Allows configuring platform-specific destination URLs for iOS, Android, and Desktop
+ALTER TABLE links ADD COLUMN ios_url TEXT;
+ALTER TABLE links ADD COLUMN android_url TEXT;
+ALTER TABLE links ADD COLUMN desktop_url TEXT;

--- a/src/api/analytics/usage.rs
+++ b/src/api/analytics/usage.rs
@@ -42,6 +42,7 @@ async fn inner(req: Request, ctx: RouteContext<()>) -> Result<Response, AppError
             "allow_custom_short_code": usage_info.limits.allow_custom_short_code,
             "allow_utm_parameters": usage_info.limits.allow_utm_parameters,
             "allow_query_forwarding": usage_info.limits.allow_query_forwarding,
+            "allow_device_routing": usage_info.limits.allow_device_routing,
             "max_tags": usage_info.limits.max_tags,
         },
         "usage": {

--- a/src/api/links/create.rs
+++ b/src/api/links/create.rs
@@ -95,13 +95,16 @@ pub async fn handle_create_link(mut req: Request, ctx: RouteContext<()>) -> Resu
         "utm_params",
         "forward_query_params",
         "redirect_type",
+        "ios_url",
+        "android_url",
+        "desktop_url",
     ];
     if let Some(obj) = raw_body.as_object() {
         for field_name in obj.keys() {
             if !expected_fields.contains(&field_name.as_str()) {
                 return Response::error(
                     format!(
-                        "Unknown field '{}'. Expected fields: destination_url, short_code (optional), title (optional), expires_at (optional), tags (optional), utm_params (optional, Pro+), forward_query_params (optional, Pro+), redirect_type (optional, defaults to 301)",
+                        "Unknown field '{}'. Expected fields: destination_url, short_code (optional), title (optional), expires_at (optional), tags (optional), utm_params (optional, Pro+), forward_query_params (optional, Pro+), redirect_type (optional, defaults to 301), ios_url (optional, Business+), android_url (optional, Business+), desktop_url (optional, Business+)",
                         field_name
                     ),
                     400,
@@ -163,6 +166,20 @@ pub async fn handle_create_link(mut req: Request, ctx: RouteContext<()>) -> Resu
             "UTM parameters and query parameter forwarding require a Pro plan or above."
         };
         return Response::error(error_msg, 403);
+    }
+
+    // Check device routing tier requirement
+    let wants_device_routing =
+        body.ios_url.is_some() || body.android_url.is_some() || body.desktop_url.is_some();
+    let allow_device_routing = limits
+        .as_ref()
+        .map(|l| l.allow_device_routing)
+        .unwrap_or(false);
+    if wants_device_routing && !allow_device_routing {
+        return Response::error(
+            "Device-based routing is available on Business tier and above.",
+            403,
+        );
     }
 
     let kv = ctx.kv("URL_MAPPINGS")?;
@@ -238,6 +255,9 @@ pub async fn handle_create_link(mut req: Request, ctx: RouteContext<()>) -> Resu
         utm_params,
         forward_query_params: body.forward_query_params,
         redirect_type: body.redirect_type.clone(),
+        ios_url: body.ios_url,
+        android_url: body.android_url,
+        desktop_url: body.desktop_url,
     };
 
     let link_service = LinkService::new();

--- a/src/api/links/import.rs
+++ b/src/api/links/import.rs
@@ -284,6 +284,9 @@ pub async fn handle_import_links(mut req: Request, ctx: RouteContext<()>) -> Res
             utm_params: None,
             forward_query_params: None,
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
         };
 
         links_to_import.push(link);

--- a/src/api/links/redirect.rs
+++ b/src/api/links/redirect.rs
@@ -2,6 +2,7 @@ use crate::kv;
 use crate::middleware::{RateLimitConfig, RateLimiter, is_kv_rate_limiting_enabled};
 use crate::models::{AnalyticsEvent, link::LinkStatus};
 use crate::repositories::LinkRepository;
+use crate::utils::device::{DeviceType, detect_device};
 use crate::utils::{get_client_ip, get_frontend_url, hash_ip, now_timestamp};
 use std::future::Future;
 use std::pin::Pin;
@@ -99,7 +100,27 @@ pub async fn handle_redirect(
         }
     }
 
-    let mut destination_url = Url::parse(&mapping.destination_url)?;
+    // Apply device-based routing if configured
+    let effective_destination = {
+        let user_agent = req.headers().get("User-Agent").ok().flatten();
+        if let Some(ref ua) = user_agent {
+            let device = detect_device(ua);
+            match device {
+                DeviceType::IOS if mapping.ios_url.is_some() => mapping.ios_url.as_ref().unwrap(),
+                DeviceType::Android if mapping.android_url.is_some() => {
+                    mapping.android_url.as_ref().unwrap()
+                }
+                DeviceType::Desktop if mapping.desktop_url.is_some() => {
+                    mapping.desktop_url.as_ref().unwrap()
+                }
+                _ => &mapping.destination_url,
+            }
+        } else {
+            &mapping.destination_url
+        }
+    };
+
+    let mut destination_url = Url::parse(effective_destination)?;
 
     if let Some(ref utm) = mapping.utm_params {
         let pairs: Vec<(&str, &str)> = [

--- a/src/api/links/update.rs
+++ b/src/api/links/update.rs
@@ -108,6 +108,12 @@ pub async fn handle_update_link(mut req: Request, ctx: RouteContext<()>) -> Resu
         .map(|u| !u.is_empty())
         .unwrap_or(false)
         || update_req.forward_query_params.is_some();
+    let wants_device_routing = update_req.ios_url.is_some()
+        || update_req.android_url.is_some()
+        || update_req.desktop_url.is_some()
+        || update_req.clear_ios_url == Some(true)
+        || update_req.clear_android_url == Some(true)
+        || update_req.clear_desktop_url == Some(true);
 
     let (billing_account_id, tier) = match link_service
         .check_pro_features_for_org(
@@ -122,6 +128,20 @@ pub async fn handle_update_link(mut req: Request, ctx: RouteContext<()>) -> Resu
         Err(crate::utils::AppError::Forbidden(msg)) => return Ok(json_error(&msg, 403)),
         Err(e) => return Err(worker::Error::RustError(e.to_string())),
     };
+
+    // Check device routing tier requirement
+    if wants_device_routing {
+        let allow_device_routing = tier
+            .as_ref()
+            .map(|t| t.limits().allow_device_routing)
+            .unwrap_or(false);
+        if !allow_device_routing {
+            return Ok(json_error(
+                "Device-based routing is available on Business tier and above.",
+                403,
+            ));
+        }
+    }
 
     let mut normalized_tags = None;
     if let Some(ref tags) = update_req.tags {
@@ -155,6 +175,23 @@ pub async fn handle_update_link(mut req: Request, ctx: RouteContext<()>) -> Resu
         update_req.expires_at.map(Some)
     };
 
+    // Handle device URL updates with clear flags
+    let ios_url_value = if update_req.clear_ios_url == Some(true) {
+        Some(None) // Clear the URL
+    } else {
+        update_req.ios_url.map(Some)
+    };
+    let android_url_value = if update_req.clear_android_url == Some(true) {
+        Some(None) // Clear the URL
+    } else {
+        update_req.android_url.map(Some)
+    };
+    let desktop_url_value = if update_req.clear_desktop_url == Some(true) {
+        Some(None) // Clear the URL
+    } else {
+        update_req.desktop_url.map(Some)
+    };
+
     let status_str = update_req.status.as_ref().map(|s| s.as_str().to_string());
 
     let updated_link = link_service
@@ -174,6 +211,9 @@ pub async fn handle_update_link(mut req: Request, ctx: RouteContext<()>) -> Resu
             update_req.forward_query_params.map(Some),
             status_str,
             update_req.redirect_type.clone(),
+            ios_url_value,
+            android_url_value,
+            desktop_url_value,
         )
         .await
         .map_err(|e| worker::Error::RustError(e.to_string()))?;

--- a/src/models/link.rs
+++ b/src/models/link.rs
@@ -104,6 +104,18 @@ pub struct Link {
     /// Default is 301 for SEO, 307 available on Pro+ plans.
     #[schema(example = "301")]
     pub redirect_type: String,
+    /// iOS-specific destination URL (Business tier feature).
+    /// Redirects iPhone/iPad users to this URL instead of the default.
+    #[schema(example = "https://apps.apple.com/app/id123456789")]
+    pub ios_url: Option<String>,
+    /// Android-specific destination URL (Business tier feature).
+    /// Redirects Android users to this URL instead of the default.
+    #[schema(example = "https://play.google.com/store/apps/details?id=com.example")]
+    pub android_url: Option<String>,
+    /// Desktop-specific destination URL (Business tier feature).
+    /// Redirects desktop users (Windows, macOS, Linux) to this URL instead of the default.
+    #[schema(example = "https://example.com/desktop-app")]
+    pub desktop_url: Option<String>,
 }
 
 impl<'de> Deserialize<'de> for Link {
@@ -127,6 +139,9 @@ impl<'de> Deserialize<'de> for Link {
             utm_params: Option<String>,        // JSON string from D1
             forward_query_params: Option<i64>, // 0/1/NULL from D1
             redirect_type: String,             // "301" or "307"
+            ios_url: Option<String>,           // Device routing URL
+            android_url: Option<String>,       // Device routing URL
+            desktop_url: Option<String>,       // Device routing URL
         }
 
         let helper = LinkHelper::deserialize(deserializer)?;
@@ -164,6 +179,9 @@ impl<'de> Deserialize<'de> for Link {
             utm_params,
             forward_query_params,
             redirect_type: helper.redirect_type,
+            ios_url: helper.ios_url,
+            android_url: helper.android_url,
+            desktop_url: helper.desktop_url,
         })
     }
 }
@@ -187,6 +205,18 @@ pub struct LinkMapping {
     /// Missing in old KV entries = "301" (safe default: permanent for SEO).
     #[serde(default = "default_redirect_type")]
     pub redirect_type: String,
+    /// iOS-specific destination URL (Business tier feature).
+    /// Missing in old KV entries = None (no device routing).
+    #[serde(default)]
+    pub ios_url: Option<String>,
+    /// Android-specific destination URL (Business tier feature).
+    /// Missing in old KV entries = None (no device routing).
+    #[serde(default)]
+    pub android_url: Option<String>,
+    /// Desktop-specific destination URL (Business tier feature).
+    /// Missing in old KV entries = None (no device routing).
+    #[serde(default)]
+    pub desktop_url: Option<String>,
 }
 
 fn default_redirect_type() -> String {
@@ -213,6 +243,15 @@ pub struct CreateLinkRequest {
     #[serde(default = "default_redirect_type")]
     #[schema(example = "301")]
     pub redirect_type: String,
+    /// iOS-specific destination URL (Business tier feature).
+    #[schema(example = "https://apps.apple.com/app/id123456789")]
+    pub ios_url: Option<String>,
+    /// Android-specific destination URL (Business tier feature).
+    #[schema(example = "https://play.google.com/store/apps/details?id=com.example")]
+    pub android_url: Option<String>,
+    /// Desktop-specific destination URL (Business tier feature).
+    #[schema(example = "https://example.com/desktop-app")]
+    pub desktop_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -237,6 +276,27 @@ pub struct UpdateLinkRequest {
     /// Available on Pro+ plans.
     #[schema(example = "307")]
     pub redirect_type: Option<String>,
+    /// iOS-specific destination URL (Business tier feature).
+    /// Set to clear the iOS URL.
+    #[schema(example = "https://apps.apple.com/app/id123456789")]
+    pub ios_url: Option<String>,
+    /// Set to true to clear the iOS URL
+    #[schema(example = false)]
+    pub clear_ios_url: Option<bool>,
+    /// Android-specific destination URL (Business tier feature).
+    /// Set to clear the Android URL.
+    #[schema(example = "https://play.google.com/store/apps/details?id=com.example")]
+    pub android_url: Option<String>,
+    /// Set to true to clear the Android URL
+    #[schema(example = false)]
+    pub clear_android_url: Option<bool>,
+    /// Desktop-specific destination URL (Business tier feature).
+    /// Set to clear the Desktop URL.
+    #[schema(example = "https://example.com/desktop-app")]
+    pub desktop_url: Option<String>,
+    /// Set to true to clear the Desktop URL
+    #[schema(example = false)]
+    pub clear_desktop_url: Option<bool>,
 }
 
 impl Link {
@@ -261,6 +321,9 @@ impl Link {
             utm_params: self.utm_params.clone(),
             forward_query_params: resolved_forward,
             redirect_type: self.redirect_type.clone(),
+            ios_url: self.ios_url.clone(),
+            android_url: self.android_url.clone(),
+            desktop_url: self.desktop_url.clone(),
         }
     }
 }
@@ -287,6 +350,9 @@ mod tests {
             utm_params: None,
             forward_query_params: None,
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
         };
         assert!(!link.is_expired());
     }
@@ -315,6 +381,9 @@ mod tests {
             utm_params: None,
             forward_query_params: None,
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
         };
         assert!(!link.is_expired());
     }
@@ -339,6 +408,9 @@ mod tests {
             utm_params: None,
             forward_query_params: None,
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
         };
         assert!(link.is_expired());
     }
@@ -361,6 +433,9 @@ mod tests {
             utm_params: None,
             forward_query_params: None,
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
         };
 
         let mapping = link.to_mapping(false);
@@ -390,6 +465,9 @@ mod tests {
             utm_params: None,
             forward_query_params: None,
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
         };
 
         let mapping = link.to_mapping(false);
@@ -455,6 +533,9 @@ mod tests {
             utm_params: Some(utm.clone()),
             forward_query_params: Some(true),
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
         };
 
         let mapping = link.to_mapping(true);
@@ -529,6 +610,9 @@ mod redirect_type_tests {
             utm_params: None,
             forward_query_params: None,
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
         };
 
         let json = serde_json::to_string(&link).unwrap();

--- a/src/models/tier.rs
+++ b/src/models/tier.rs
@@ -41,6 +41,7 @@ impl Tier {
                 allow_custom_short_code: false,
                 allow_utm_parameters: false,
                 allow_query_forwarding: false,
+                allow_device_routing: false,
                 allow_api_keys: false,
                 max_members: Some(1),
                 max_orgs: Some(1),
@@ -53,6 +54,7 @@ impl Tier {
                 allow_custom_short_code: true,
                 allow_utm_parameters: true,
                 allow_query_forwarding: true,
+                allow_device_routing: false,
                 allow_api_keys: true,
                 max_members: Some(1),
                 max_orgs: Some(1),
@@ -65,6 +67,7 @@ impl Tier {
                 allow_custom_short_code: true,
                 allow_utm_parameters: true,
                 allow_query_forwarding: true,
+                allow_device_routing: true,
                 allow_api_keys: true,
                 max_members: Some(20),
                 max_orgs: Some(3),
@@ -77,6 +80,7 @@ impl Tier {
                 allow_custom_short_code: true,
                 allow_utm_parameters: true,
                 allow_query_forwarding: true,
+                allow_device_routing: true,
                 allow_api_keys: true,
                 max_members: None,
                 max_orgs: None,
@@ -106,6 +110,8 @@ pub struct TierLimits {
     pub allow_utm_parameters: bool,
     /// Whether query parameter forwarding is allowed for this tier.
     pub allow_query_forwarding: bool,
+    /// Whether device-based routing (iOS/Android/Desktop URLs) is allowed for this tier.
+    pub allow_device_routing: bool,
     /// Whether API key creation and usage is allowed for this tier.
     pub allow_api_keys: bool,
     /// Maximum members per organization (including owner). None = unlimited.

--- a/src/repositories/link_repository.rs
+++ b/src/repositories/link_repository.rs
@@ -57,6 +57,9 @@ pub struct AdminLinkBase {
     #[serde(serialize_with = "serialize_optional_int_as_bool")]
     pub forward_query_params: Option<i64>, // Stored as INTEGER in D1 (0/1/NULL)
     pub redirect_type: String,
+    pub ios_url: Option<String>,
+    pub android_url: Option<String>,
+    pub desktop_url: Option<String>,
     pub creator_email: String,
     pub org_name: String,
 }
@@ -87,8 +90,8 @@ impl LinkRepository {
         let utm_json = link.utm_params.as_ref().and_then(|u| u.to_json_string());
 
         let stmt = db.prepare(
-            "INSERT INTO links (id, org_id, short_code, destination_url, title, created_by, created_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)"
+            "INSERT INTO links (id, org_id, short_code, destination_url, title, created_by, created_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type, ios_url, android_url, desktop_url)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)"
         );
 
         stmt.bind(&[
@@ -112,6 +115,18 @@ impl LinkRepository {
                 .map(|v| (if v { 1i64 } else { 0i64 } as f64).into())
                 .unwrap_or(JsValue::NULL),
             link.redirect_type.clone().into(),
+            link.ios_url
+                .clone()
+                .map(|s| s.into())
+                .unwrap_or(JsValue::NULL),
+            link.android_url
+                .clone()
+                .map(|s| s.into())
+                .unwrap_or(JsValue::NULL),
+            link.desktop_url
+                .clone()
+                .map(|s| s.into())
+                .unwrap_or(JsValue::NULL),
         ])?
         .run()
         .await?;
@@ -127,7 +142,7 @@ impl LinkRepository {
         org_id: &str,
     ) -> Result<Option<Link>> {
         let stmt = db.prepare(
-            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type
+            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type, ios_url, android_url, desktop_url
              FROM links
              WHERE id = ?1
              AND org_id = ?2
@@ -141,7 +156,7 @@ impl LinkRepository {
     /// Get a link by ID without org check — active only (public redirects)
     pub async fn get_by_id_no_auth(&self, db: &D1Database, link_id: &str) -> Result<Option<Link>> {
         let stmt = db.prepare(
-            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type
+            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type, ios_url, android_url, desktop_url
              FROM links
              WHERE id = ?1
              AND status = 'active'"
@@ -156,7 +171,7 @@ impl LinkRepository {
         link_id: &str,
     ) -> Result<Option<Link>> {
         let stmt = db.prepare(
-            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type
+            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type, ios_url, android_url, desktop_url
              FROM links
              WHERE id = ?1"
         );
@@ -171,7 +186,7 @@ impl LinkRepository {
         org_id: &str,
     ) -> Result<Option<Link>> {
         let stmt = db.prepare(
-            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type
+            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type, ios_url, android_url, desktop_url
              FROM links
              WHERE short_code = ?1
              AND org_id = ?2
@@ -189,7 +204,7 @@ impl LinkRepository {
         short_code: &str,
     ) -> Result<Option<Link>> {
         let stmt = db.prepare(
-            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type
+            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type, ios_url, android_url, desktop_url
              FROM links
              WHERE short_code = ?1
              AND status = 'active'"
@@ -211,7 +226,7 @@ impl LinkRepository {
         tags_filter: Option<&[String]>,
     ) -> Result<Vec<Link>> {
         let mut query = String::from(
-            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type
+            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type, ios_url, android_url, desktop_url
              FROM links
              WHERE org_id = ?1"
         );
@@ -343,7 +358,8 @@ impl LinkRepository {
     }
 
     /// Update a link. Only provided fields are changed.
-    /// For expires_at: None = don't update, Some(None) = clear to NULL, Some(Some(ts)) = set to timestamp
+    /// For expires_at, utm_params, forward_query_params, device URLs:
+    ///   None = don't update, Some(None) = clear to NULL, Some(Some(val)) = set to value
     #[allow(clippy::too_many_arguments)]
     pub async fn update(
         &self,
@@ -357,6 +373,9 @@ impl LinkRepository {
         utm_params: Option<Option<&str>>,
         forward_query_params: Option<Option<bool>>,
         redirect_type: Option<&str>,
+        ios_url: Option<Option<&str>>,
+        android_url: Option<Option<&str>>,
+        desktop_url: Option<Option<&str>>,
     ) -> Result<Link> {
         let now = now_timestamp();
 
@@ -411,6 +430,24 @@ impl LinkRepository {
         if let Some(rt) = redirect_type {
             query.push_str(&format!(", redirect_type = ?{}", param_count));
             params.push(rt.into());
+            param_count += 1;
+        }
+
+        if let Some(ios_val) = ios_url {
+            query.push_str(&format!(", ios_url = ?{}", param_count));
+            params.push(ios_val.map(|s| s.into()).unwrap_or(JsValue::NULL));
+            param_count += 1;
+        }
+
+        if let Some(android_val) = android_url {
+            query.push_str(&format!(", android_url = ?{}", param_count));
+            params.push(android_val.map(|s| s.into()).unwrap_or(JsValue::NULL));
+            param_count += 1;
+        }
+
+        if let Some(desktop_val) = desktop_url {
+            query.push_str(&format!(", desktop_url = ?{}", param_count));
+            params.push(desktop_val.map(|s| s.into()).unwrap_or(JsValue::NULL));
             param_count += 1;
         }
 
@@ -631,7 +668,7 @@ impl LinkRepository {
     /// Get all active/disabled links for an org (for CSV/JSON export)
     pub async fn get_all_for_export(&self, db: &D1Database, org_id: &str) -> Result<Vec<Link>> {
         let stmt = db.prepare(
-            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type
+            "SELECT id, org_id, short_code, destination_url, title, created_by, created_at, updated_at, expires_at, status, click_count, utm_params, forward_query_params, redirect_type, ios_url, android_url, desktop_url
              FROM links
              WHERE org_id = ?1
              AND status IN ('active', 'disabled')
@@ -654,7 +691,7 @@ impl LinkRepository {
         domain_filter: Option<&str>,
     ) -> Result<Vec<AdminLinkBase>> {
         let mut query = String::from(
-            "SELECT l.id, l.org_id, l.short_code, l.destination_url, l.title, l.created_by, l.created_at, l.updated_at, l.expires_at, l.status, l.click_count, l.utm_params, l.forward_query_params, l.redirect_type, u.email as creator_email, o.name as org_name
+            "SELECT l.id, l.org_id, l.short_code, l.destination_url, l.title, l.created_by, l.created_at, l.updated_at, l.expires_at, l.status, l.click_count, l.utm_params, l.forward_query_params, l.redirect_type, l.ios_url, l.android_url, l.desktop_url, u.email as creator_email, o.name as org_name
              FROM links l
              JOIN users u ON l.created_by = u.id
              JOIN organizations o ON l.org_id = o.id
@@ -913,6 +950,9 @@ mod admin_link_serialization_tests {
             utm_params: None,
             forward_query_params: Some(1),
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
             creator_email: "test@example.com".to_string(),
             org_name: "Test Org".to_string(),
         };
@@ -941,6 +981,9 @@ mod admin_link_serialization_tests {
             utm_params: None,
             forward_query_params: Some(0),
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
             creator_email: "test@example.com".to_string(),
             org_name: "Test Org".to_string(),
         };
@@ -968,6 +1011,9 @@ mod admin_link_serialization_tests {
             utm_params: None,
             forward_query_params: None,
             redirect_type: "301".to_string(),
+            ios_url: None,
+            android_url: None,
+            desktop_url: None,
             creator_email: "test@example.com".to_string(),
             org_name: "Test Org".to_string(),
         };

--- a/src/repositories/report_repository.rs
+++ b/src/repositories/report_repository.rs
@@ -71,6 +71,9 @@ pub struct LinkReportQueryResult {
     #[serde(serialize_with = "serialize_optional_int_as_bool")]
     pub link__forward_query_params: Option<i64>, // Stored as INTEGER in D1 (0/1/NULL)
     pub link__redirect_type: String,
+    pub link__ios_url: Option<String>,
+    pub link__android_url: Option<String>,
+    pub link__desktop_url: Option<String>,
     pub link__creator_email: String,
     pub link__org_name: String,
     pub report_count: i64,
@@ -176,6 +179,7 @@ impl ReportRepository {
                 l.status as link__status, l.click_count as link__click_count,
                 l.utm_params as link__utm_params, l.forward_query_params as link__forward_query_params,
                 l.redirect_type as link__redirect_type,
+                l.ios_url as link__ios_url, l.android_url as link__android_url, l.desktop_url as link__desktop_url,
                 u.email as link__creator_email, o.name as link__org_name,
                 COUNT(lr_sub.id) as report_count
              FROM link_reports lr
@@ -230,6 +234,9 @@ impl ReportRepository {
                         utm_params: qr.link__utm_params,
                         forward_query_params: qr.link__forward_query_params,
                         redirect_type: qr.link__redirect_type,
+                        ios_url: qr.link__ios_url,
+                        android_url: qr.link__android_url,
+                        desktop_url: qr.link__desktop_url,
                         creator_email: qr.link__creator_email,
                         org_name: qr.link__org_name,
                     },
@@ -390,6 +397,9 @@ mod link_report_serialization_tests {
             "link__utm_params": null,
             "link__forward_query_params": 1,
             "link__redirect_type": "301",
+            "link__ios_url": null,
+            "link__android_url": null,
+            "link__desktop_url": null,
             "link__creator_email": "creator@example.com",
             "link__org_name": "Test Org",
             "report_count": 1
@@ -427,6 +437,9 @@ mod link_report_serialization_tests {
             link__utm_params: None,
             link__forward_query_params: Some(1),
             link__redirect_type: "301".to_string(),
+            link__ios_url: None,
+            link__android_url: None,
+            link__desktop_url: None,
             link__creator_email: "creator@example.com".to_string(),
             link__org_name: "Test Org".to_string(),
             report_count: 1,

--- a/src/services/link_service.rs
+++ b/src/services/link_service.rs
@@ -258,8 +258,7 @@ impl LinkService {
         let repo = LinkRepository::new();
 
         // Verify link exists and belongs to org
-        let _existing = repo
-            .get_by_id(db, link_id, org_id)
+        repo.get_by_id(db, link_id, org_id)
             .await?
             .ok_or_else(|| AppError::NotFound("Link not found".to_string()))?;
 

--- a/src/services/link_service.rs
+++ b/src/services/link_service.rs
@@ -258,7 +258,7 @@ impl LinkService {
         let repo = LinkRepository::new();
 
         // Verify link exists and belongs to org
-        let existing = repo
+        let _existing = repo
             .get_by_id(db, link_id, org_id)
             .await?
             .ok_or_else(|| AppError::NotFound("Link not found".to_string()))?;
@@ -293,16 +293,19 @@ impl LinkService {
             )
             .await?;
 
-        // Sync KV if status changed
-        if let Some(ref new_status_str) = status {
-            let new_status = match new_status_str.as_str() {
-                "active" => LinkStatus::Active,
-                "disabled" => LinkStatus::Disabled,
-                "blocked" => LinkStatus::Blocked,
-                _ => return Ok(updated),
-            };
+        // Determine if KV sync is needed
+        // Sync if: status changed, destination_url changed, device URLs changed, redirect_type changed, or expires_at changed
+        let needs_kv_sync = status.is_some()
+            || destination_url.is_some()
+            || ios_url.is_some()
+            || android_url.is_some()
+            || desktop_url.is_some()
+            || redirect_type.is_some()
+            || expires_at.is_some();
 
-            if new_status != existing.status {
+        if needs_kv_sync {
+            // Only sync to KV if the link is active
+            if updated.status == LinkStatus::Active {
                 // Get org default for forward_query_params if needed
                 let org_repo = crate::repositories::OrgRepository::new();
                 let resolved_forward = if updated.forward_query_params.is_none() {
@@ -314,15 +317,12 @@ impl LinkService {
                     updated.forward_query_params.unwrap_or(false)
                 };
 
-                if new_status == LinkStatus::Active {
-                    // Re-enable in KV by storing the mapping
-                    let mapping = updated.to_mapping(resolved_forward);
-                    crate::kv::store_link_mapping(kv, org_id, &updated.short_code, &mapping)
-                        .await?;
-                } else {
-                    // Disable in KV
-                    crate::kv::delete_link_mapping(kv, org_id, &updated.short_code).await?;
-                }
+                // Update KV with new mapping
+                let mapping = updated.to_mapping(resolved_forward);
+                crate::kv::store_link_mapping(kv, org_id, &updated.short_code, &mapping).await?;
+            } else {
+                // Link is not active, ensure it's removed from KV
+                crate::kv::delete_link_mapping(kv, org_id, &updated.short_code).await?;
             }
         }
 

--- a/src/services/link_service.rs
+++ b/src/services/link_service.rs
@@ -251,6 +251,9 @@ impl LinkService {
         forward_query_params: Option<Option<bool>>,
         status: Option<String>,
         redirect_type: Option<String>,
+        ios_url: Option<Option<String>>,
+        android_url: Option<Option<String>>,
+        desktop_url: Option<Option<String>>,
     ) -> Result<Link, AppError> {
         let repo = LinkRepository::new();
 
@@ -266,6 +269,11 @@ impl LinkService {
         let utm_ref: Option<Option<&str>> =
             utm_string.as_ref().map(|o| o.as_ref().map(|s| s.as_str()));
 
+        // Convert device URLs for repository
+        let ios_ref: Option<Option<&str>> = ios_url.as_ref().map(|o| o.as_deref());
+        let android_ref: Option<Option<&str>> = android_url.as_ref().map(|o| o.as_deref());
+        let desktop_ref: Option<Option<&str>> = desktop_url.as_ref().map(|o| o.as_deref());
+
         // Update the link (single call handles all fields)
         let updated = repo
             .update(
@@ -279,6 +287,9 @@ impl LinkService {
                 utm_ref, // utm_params as Option<Option<&str>>
                 forward_query_params,
                 redirect_type.as_deref(),
+                ios_ref,
+                android_ref,
+                desktop_ref,
             )
             .await?;
 
@@ -436,6 +447,9 @@ impl LinkService {
                 forward_query_params: link.forward_query_params.unwrap_or(false),
                 utm_params: link.utm_params.clone(),
                 redirect_type: link.redirect_type.clone(),
+                ios_url: link.ios_url.clone(),
+                android_url: link.android_url.clone(),
+                desktop_url: link.desktop_url.clone(),
             };
             crate::kv::store_link_mapping(kv, &link.org_id, &link.short_code, &mapping).await?;
         } else {
@@ -553,6 +567,9 @@ impl LinkService {
                     utm_params: link.utm_params,
                     forward_query_params: link.forward_query_params,
                     redirect_type: link.redirect_type.clone(),
+                    ios_url: link.ios_url.clone(),
+                    android_url: link.android_url.clone(),
+                    desktop_url: link.desktop_url.clone(),
                 };
                 let org_repo = crate::repositories::OrgRepository::new();
                 let resolved_forward = if let Some(forward) = link.forward_query_params {

--- a/src/utils/device.rs
+++ b/src/utils/device.rs
@@ -1,0 +1,194 @@
+//! Device detection based on User-Agent header.
+//! Lightweight implementation without external crates for sub-millisecond detection.
+
+/// Represents the type of device based on User-Agent analysis.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DeviceType {
+    /// iOS devices (iPhone, iPad, iPod)
+    IOS,
+    /// Android devices (phones and tablets)
+    Android,
+    /// Desktop devices (Windows, macOS, Linux)
+    Desktop,
+    /// Unknown or unrecognized devices (bots, crawlers, etc.)
+    Other,
+}
+
+impl DeviceType {
+    /// Returns a string representation of the device type.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DeviceType::IOS => "ios",
+            DeviceType::Android => "android",
+            DeviceType::Desktop => "desktop",
+            DeviceType::Other => "other",
+        }
+    }
+}
+
+/// Detect the device type from a User-Agent string.
+///
+/// Detection order matters - more specific patterns are checked first.
+/// This implementation prioritizes accuracy for the most common device types.
+pub fn detect_device(user_agent: &str) -> DeviceType {
+    let ua = user_agent.to_lowercase();
+
+    // Check for iOS first (includes iPhone, iPad, iPod)
+    // iPad in iPadOS 13+ may report as "Macintosh" with "Safari" but still has touch indicators
+    if ua.contains("iphone")
+        || ua.contains("ipad")
+        || ua.contains("ipod")
+        || (ua.contains("macintosh") && ua.contains("mobile"))
+    {
+        return DeviceType::IOS;
+    }
+
+    // Check for Android (but not Android TV or other variants)
+    if ua.contains("android") && !ua.contains("android tv") && !ua.contains("androidtv") {
+        return DeviceType::Android;
+    }
+
+    // Check for mobile indicators - if present but not iOS/Android, categorize as Other
+    // This catches Windows Phone, BlackBerry, etc.
+    if ua.contains("mobile") || ua.contains("phone") || ua.contains("mobi") {
+        return DeviceType::Other;
+    }
+
+    // Desktop patterns (Windows, macOS, Linux)
+    // These checks come after mobile to avoid misclassifying mobile devices
+    if ua.contains("windows")
+        || ua.contains("macintosh")
+        || ua.contains("mac os")
+        || ua.contains("linux")
+        || ua.contains("x11")
+        || ua.contains("x64")
+        || ua.contains("x86_64")
+        || ua.contains("wow64")
+    {
+        return DeviceType::Desktop;
+    }
+
+    // Default to Other for unrecognized User-Agents
+    // This includes bots, crawlers, and obscure devices
+    DeviceType::Other
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // iOS User-Agents
+    const UA_IPHONE_SAFARI: &str = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1";
+    const UA_IPAD_SAFARI: &str = "Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1";
+    const UA_IPOD: &str = "Mozilla/5.0 (iPod touch; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1";
+    const UA_IPADOS_CHROME: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Mobile";
+
+    // Android User-Agents
+    const UA_ANDROID_CHROME: &str = "Mozilla/5.0 (Linux; Android 13; SM-S901B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile Safari/537.36";
+    const UA_ANDROID_TABLET: &str = "Mozilla/5.0 (Linux; Android 12; SM-T870) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36";
+    const UA_ANDROID_FIREFOX: &str =
+        "Mozilla/5.0 (Android 13; Mobile; rv:109.0) Gecko/20100101 Firefox/112.0";
+
+    // Desktop User-Agents
+    const UA_WINDOWS_CHROME: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36";
+    const UA_WINDOWS_FIREFOX: &str =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/112.0";
+    const UA_MACOS_SAFARI: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15";
+    const UA_MACOS_CHROME: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36";
+    const UA_LINUX_FIREFOX: &str =
+        "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/112.0";
+    const UA_LINUX_CHROME: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36";
+
+    // Other/Bot User-Agents
+    const UA_GOOGLEBOT: &str =
+        "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+    const UA_CURL: &str = "curl/7.88.1";
+    const UA_POSTMAN: &str = "PostmanRuntime/7.32.3";
+    const UA_EMPTY: &str = "";
+
+    #[test]
+    fn test_detect_ios_iphone() {
+        assert_eq!(detect_device(UA_IPHONE_SAFARI), DeviceType::IOS);
+    }
+
+    #[test]
+    fn test_detect_ios_ipad() {
+        assert_eq!(detect_device(UA_IPAD_SAFARI), DeviceType::IOS);
+    }
+
+    #[test]
+    fn test_detect_ios_ipod() {
+        assert_eq!(detect_device(UA_IPOD), DeviceType::IOS);
+    }
+
+    #[test]
+    fn test_detect_ios_ipados_chrome() {
+        // iPad Pro with iPadOS may report as Macintosh with Mobile indicator
+        assert_eq!(detect_device(UA_IPADOS_CHROME), DeviceType::IOS);
+    }
+
+    #[test]
+    fn test_detect_android_phone() {
+        assert_eq!(detect_device(UA_ANDROID_CHROME), DeviceType::Android);
+    }
+
+    #[test]
+    fn test_detect_android_tablet() {
+        assert_eq!(detect_device(UA_ANDROID_TABLET), DeviceType::Android);
+    }
+
+    #[test]
+    fn test_detect_android_firefox() {
+        assert_eq!(detect_device(UA_ANDROID_FIREFOX), DeviceType::Android);
+    }
+
+    #[test]
+    fn test_detect_desktop_windows_chrome() {
+        assert_eq!(detect_device(UA_WINDOWS_CHROME), DeviceType::Desktop);
+    }
+
+    #[test]
+    fn test_detect_desktop_windows_firefox() {
+        assert_eq!(detect_device(UA_WINDOWS_FIREFOX), DeviceType::Desktop);
+    }
+
+    #[test]
+    fn test_detect_desktop_macos_safari() {
+        assert_eq!(detect_device(UA_MACOS_SAFARI), DeviceType::Desktop);
+    }
+
+    #[test]
+    fn test_detect_desktop_macos_chrome() {
+        assert_eq!(detect_device(UA_MACOS_CHROME), DeviceType::Desktop);
+    }
+
+    #[test]
+    fn test_detect_desktop_linux_firefox() {
+        assert_eq!(detect_device(UA_LINUX_FIREFOX), DeviceType::Desktop);
+    }
+
+    #[test]
+    fn test_detect_desktop_linux_chrome() {
+        assert_eq!(detect_device(UA_LINUX_CHROME), DeviceType::Desktop);
+    }
+
+    #[test]
+    fn test_detect_other_bots() {
+        assert_eq!(detect_device(UA_GOOGLEBOT), DeviceType::Other);
+        assert_eq!(detect_device(UA_CURL), DeviceType::Other);
+        assert_eq!(detect_device(UA_POSTMAN), DeviceType::Other);
+    }
+
+    #[test]
+    fn test_detect_other_empty() {
+        assert_eq!(detect_device(UA_EMPTY), DeviceType::Other);
+    }
+
+    #[test]
+    fn test_device_type_as_str() {
+        assert_eq!(DeviceType::IOS.as_str(), "ios");
+        assert_eq!(DeviceType::Android.as_str(), "android");
+        assert_eq!(DeviceType::Desktop.as_str(), "desktop");
+        assert_eq!(DeviceType::Other.as_str(), "other");
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod crypto;
+pub mod device;
 pub mod email;
 pub mod env;
 pub mod errors;


### PR DESCRIPTION
Add ability to set different destination URLs for iOS, Android, and Desktop devices. Users on Business and Unlimited tiers can configure device-specific redirects that automatically route visitors based on their device type.

Backend changes:
- Add device detection module (src/utils/device.rs) with User-Agent parsing
- Add device URL columns (ios_url, android_url, desktop_url) to links table
- Update Link and LinkMapping models with device URL fields
- Integrate device detection into redirect handler for automatic routing
- Add tier gating for device routing (Business+ only)
- Update all repository queries to include device URL fields
- Fix usage API to return allow_device_routing flag

Frontend changes:
- Add device routing UI to LinkModal with collapsible section
- Show device-specific URL inputs (iOS, Android, Desktop) with icons
- Display upgrade CTA for Free/Pro tiers
- Update TypeScript API types with device URL fields

The feature is backward compatible - existing links continue to work normally, falling back to the default destination URL when device-specific URLs are not set.

Closes #108 