### PR TITLE
Add SEO comparison pages and fix hydration issues

### DIFF
--- a/frontend/scripts/generate-sitemap.js
+++ b/frontend/scripts/generate-sitemap.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
 import { writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
-import { dirname, resolve } from "path";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -22,8 +21,9 @@ const pagesContent = pagesMatch ? pagesMatch[1] : "";
 
 // Parse the pages array (simplified - just extract path, changefreq, priority)
 const PUBLIC_PAGES = [];
+// Handle both single and double quotes, and multi-line formatting
 const pageMatches = pagesContent.matchAll(
-  /\{ path: '([^']+)', changefreq: '([^']+)', priority: '([^']+)'/g
+  /\{\s*path:\s*["']([^"']+)["']\s*,\s*changefreq:\s*["']([^"']+)["']\s*,\s*priority:\s*["']([^"']+)["']/g
 );
 for (const match of pageMatches) {
   PUBLIC_PAGES.push({

--- a/frontend/src/config/competitors.ts
+++ b/frontend/src/config/competitors.ts
@@ -1,0 +1,261 @@
+export interface CompetitorFeature {
+  feature: string;
+  rushomon: string | boolean;
+  competitor: string | boolean;
+}
+
+export interface Competitor {
+  slug: string;
+  name: string;
+  tagline: string;
+  heroHeading: string;
+  heroSubheading: string;
+  metaTitle: string;
+  metaDescription: string;
+  mainPitch: string;
+  features: CompetitorFeature[];
+  whyRushomon: { title: string; body: string }[];
+}
+
+export const COMPETITORS: Record<string, Competitor> = {
+  bitly: {
+    slug: "bitly",
+    name: "Bitly",
+    tagline: "The most popular link shortener",
+    heroHeading: "The Open Source Bitly Alternative",
+    heroSubheading:
+      "Everything Bitly offers — click analytics, branded links — without the $299/month price tag or the data lock-in.",
+    metaTitle: "Bitly Alternative — Open Source URL Shortener | Rushomon",
+    metaDescription:
+      "Looking for a Bitly alternative? Rushomon is a free, open source URL shortener with analytics and self-hosting. No lock-in, your data.",
+    mainPitch:
+      "Bitly is the category leader, but its pricing starts at $8/month and quickly escalates to $199–$299/month for teams wanting analytics history. Rushomon gives you the same core capabilities — short links, click analytics — on a generous free tier, with no lock-in because it's open source and self-hostable.",
+    features: [
+      {
+        feature: "Free tier",
+        rushomon: "Yes — 15 links/month",
+        competitor: "Yes — 5 links/month"
+      },
+      {
+        feature: "Custom short codes",
+        rushomon: "Yes (Pro)",
+        competitor: "Yes (paid)"
+      },
+      {
+        feature: "Click analytics",
+        rushomon: "Yes",
+        competitor: "Yes"
+      },
+      {
+        feature: "Analytics retention (free)",
+        rushomon: "7 days",
+        competitor: "None — paid plans only"
+      },
+      {
+        feature: "Open source",
+        rushomon: "Yes (AGPL-3.0)",
+        competitor: "No"
+      },
+      {
+        feature: "Self-hostable",
+        rushomon: "Yes — Cloudflare Workers",
+        competitor: "No"
+      },
+      {
+        feature: "Data ownership",
+        rushomon: "Full ownership",
+        competitor: "Bitly owns your data"
+      },
+      {
+        feature: "API access",
+        rushomon: "Yes (Pro)",
+        competitor: "Yes (paid)"
+      },
+      {
+        feature: "Team features",
+        rushomon: "Yes (Business)",
+        competitor: "Yes (Enterprise)"
+      }
+    ],
+    whyRushomon: [
+      {
+        title: "No data lock-in",
+        body: "Your links and analytics data belong to you. Export at any time, or self-host for complete control."
+      },
+      {
+        title: "Transparent pricing",
+        body: "Free tier for individuals, affordable Pro and Business plans. No surprise bills or feature gates for basic analytics."
+      },
+      {
+        title: "Open source",
+        body: "Built with Rust and SvelteKit under AGPL-3.0. Audit the code, fork it, or contribute improvements."
+      }
+    ]
+  },
+  dub: {
+    slug: "dub",
+    name: "Dub.co",
+    tagline: "The modern developer-focused link shortener",
+    heroHeading: "Self-Host Instead of Dub.co",
+    heroSubheading:
+      "Dub is great, but at $24–$99/month it adds up. Rushomon is open source and self-hostable on Cloudflare Workers — one-time setup, zero monthly SaaS fees.",
+    metaTitle: "Dub Alternative — Self-Hosted URL Shortener | Rushomon",
+    metaDescription:
+      "Looking for a Dub.co alternative you can self-host? Rushomon runs on Cloudflare Workers, is fully open source, and has a generous free tier.",
+    mainPitch:
+      "Dub.co is a polished modern tool beloved by developers. But its free plan caps you at 1,000 tracked events per month — once your links get any real traffic, you're forced onto a paid tier. Rushomon tracks unlimited clicks with no event caps. And if you're comfortable with Cloudflare Workers, self-hosting gives you the full feature set with zero monthly fees and no third-party dependency.",
+    features: [
+      {
+        feature: "Free tier",
+        rushomon: "Yes — 15 links/month",
+        competitor: "Yes — 25 links/month"
+      },
+      {
+        feature: "Analytics retention (free)",
+        rushomon: "7 days",
+        competitor: "30 days"
+      },
+      {
+        feature: "Custom short codes",
+        rushomon: "Yes (Pro)",
+        competitor: "Yes (paid)"
+      },
+      {
+        feature: "Click tracking",
+        rushomon: "Unlimited clicks",
+        competitor: "1K events/month (free)"
+      },
+      {
+        feature: "Click analytics",
+        rushomon: "Yes",
+        competitor: "Yes"
+      },
+      {
+        feature: "Open source",
+        rushomon: "Yes (AGPL-3.0)",
+        competitor: "Yes (AGPLv3)"
+      },
+      {
+        feature: "Self-hostable",
+        rushomon: "Yes — Cloudflare Workers",
+        competitor: "Yes — complex infra"
+      },
+      {
+        feature: "Cloudflare-native",
+        rushomon: "Yes — built for Workers + KV + D1",
+        competitor: "No — requires own server"
+      },
+      {
+        feature: "API access",
+        rushomon: "Yes (Pro)",
+        competitor: "Yes (free)"
+      },
+      {
+        feature: "Team features",
+        rushomon: "Yes (Business)",
+        competitor: "Yes (paid)"
+      },
+      {
+        feature: "Password protection",
+        rushomon: "Yes (Business)",
+        competitor: "Yes (paid)"
+      }
+    ],
+    whyRushomon: [
+      {
+        title: "Cloudflare-native by design",
+        body: "Rushomon is built specifically for Cloudflare Workers, KV, and D1. Sub-millisecond redirects at the edge globally — not an afterthought."
+      },
+      {
+        title: "Zero-dependency self-hosting",
+        body: "No servers, no Docker, no databases to manage. One wrangler deploy command and you're running your own link shortener at the edge."
+      },
+      {
+        title: "Familiar stack",
+        body: "Rust backend compiling to WebAssembly, SvelteKit frontend. Modern, performant, and easy to contribute to."
+      }
+    ]
+  },
+  "short-io": {
+    slug: "short-io",
+    name: "Short.io",
+    tagline: "A popular link shortener for teams",
+    heroHeading: "Free Short.io Alternative with Full Data Ownership",
+    heroSubheading:
+      "Short.io caps free users at 1,000 total links and hides analytics after 50K clicks. Rushomon is open source, self-hostable, and never gates your own data.",
+    metaTitle:
+      "Short.io Alternative — Free, Open Source URL Shortener | Rushomon",
+    metaDescription:
+      "Looking for a Short.io alternative? Rushomon is free, open source, and self-hostable. Get click analytics and team support without $19/month.",
+    mainPitch:
+      "Short.io is a solid commercial URL shortener, but its free plan caps you at 1,000 total links ever and stops showing you analytics after 50,000 clicks per month — the data keeps being collected, you just can't see it without upgrading. It's also fully closed-source, so you're entirely dependent on their servers and business decisions. Rushomon is open source under AGPL-3.0, has no analytics visibility gates, and can be self-hosted on Cloudflare Workers if you want full control.",
+    features: [
+      {
+        feature: "Free tier",
+        rushomon: "Yes — 15 links/month",
+        competitor: "Yes — 1,000 links total"
+      },
+      {
+        feature: "Click tracking",
+        rushomon: "Unlimited clicks",
+        competitor: "50K/month (then hidden)"
+      },
+      {
+        feature: "Custom short codes",
+        rushomon: "Yes (Pro)",
+        competitor: "Yes (paid)"
+      },
+      {
+        feature: "Click analytics",
+        rushomon: "Yes",
+        competitor: "Yes (capped on free)"
+      },
+      {
+        feature: "Open source",
+        rushomon: "Yes (AGPL-3.0)",
+        competitor: "No"
+      },
+      {
+        feature: "Self-hostable",
+        rushomon: "Yes — Cloudflare Workers",
+        competitor: "No"
+      },
+      {
+        feature: "Data ownership",
+        rushomon: "Full ownership",
+        competitor: "Vendor-controlled"
+      },
+      {
+        feature: "API access",
+        rushomon: "Yes (Pro)",
+        competitor: "Yes (paid)"
+      },
+      {
+        feature: "Team features",
+        rushomon: "Yes (Business)",
+        competitor: "Yes (paid)"
+      },
+      {
+        feature: "QR code generation",
+        rushomon: "Yes",
+        competitor: "Yes"
+      }
+    ],
+    whyRushomon: [
+      {
+        title: "Your links, your rules",
+        body: "Being open source means you can inspect every line of code and self-host if you want zero dependency on Rushomon's servers."
+      },
+      {
+        title: "No vendor lock-in",
+        body: "Export your full link library at any time. If Rushomon ever disappeared, you could run the open source code yourself."
+      },
+      {
+        title: "Cloudflare edge performance",
+        body: "Links resolve at the nearest Cloudflare data center, giving you sub-millisecond redirects for users anywhere in the world."
+      }
+    ]
+  }
+};
+
+export const COMPETITOR_SLUGS = Object.keys(COMPETITORS);

--- a/frontend/src/config/use-cases.ts
+++ b/frontend/src/config/use-cases.ts
@@ -1,0 +1,181 @@
+export interface UseCaseFeature {
+  title: string;
+  body: string;
+}
+
+export interface UseCase {
+  slug: string;
+  heroHeading: string;
+  heroSubheading: string;
+  metaTitle: string;
+  metaDescription: string;
+  intro: string;
+  features: UseCaseFeature[];
+  faqs: { q: string; a: string }[];
+}
+
+export const USE_CASES: Record<string, UseCase> = {
+  "self-hosted": {
+    slug: "self-hosted",
+    heroHeading: "Self-Hosted URL Shortener on Cloudflare Workers",
+    heroSubheading:
+      "Run your own link shortener at the edge. One wrangler deploy, your domain, zero monthly SaaS fees.",
+    metaTitle: "Self-Hosted URL Shortener — Cloudflare Workers | Rushomon",
+    metaDescription:
+      "Rushomon is a self-hosted URL shortener built for Cloudflare Workers. Open source, free to host, sub-millisecond redirects globally. No servers to manage.",
+    intro:
+      "Most URL shorteners are SaaS products — you pay monthly, you depend on their uptime, and your data lives on their servers. Rushomon takes a different approach: it's open source software you deploy to your own Cloudflare account in minutes. You get global edge performance, full data ownership, and no ongoing SaaS fees.",
+    features: [
+      {
+        title: "Deploys in minutes",
+        body: "Clone the repo, set your secrets, run wrangler deploy. Your URL shortener is live at your domain with sub-millisecond global performance."
+      },
+      {
+        title: "Zero infrastructure to manage",
+        body: "Runs on Cloudflare Workers (serverless), KV (edge key-value store), and D1 (SQLite at the edge). No servers, no Docker, no databases to maintain."
+      },
+      {
+        title: "Your domain, your brand",
+        body: "Use any domain you own as your short link domain. rush.mn, go.yourbrand.com, links.company.io — it's all yours."
+      },
+      {
+        title: "Full data ownership",
+        body: "All link data, click analytics, and user accounts live in your Cloudflare account. You can export or delete everything at any time."
+      },
+      {
+        title: "Open source codebase",
+        body: "Every line of code is public on GitHub under AGPL-3.0. Audit it, extend it, or contribute improvements."
+      },
+      {
+        title: "Free Cloudflare tier is enough",
+        body: "Cloudflare's free plan covers the Workers, KV, and D1 resources needed to run a personal or small-team URL shortener."
+      }
+    ],
+    faqs: [
+      {
+        q: "Do I need a paid Cloudflare account?",
+        a: "No. Rushomon runs within Cloudflare's free tier limits for personal and small team use. A paid Workers plan is only needed for very high traffic volumes."
+      },
+      {
+        q: "How long does setup take?",
+        a: "Around 15–30 minutes for a first-time Cloudflare Workers deployment. The SELF_HOSTING.md guide walks through every step."
+      },
+      {
+        q: "What happens if Rushomon the company disappears?",
+        a: "Nothing changes for self-hosters. The open source code continues to exist on GitHub, and your deployment keeps running on your Cloudflare account."
+      }
+    ]
+  },
+  "open-source": {
+    slug: "open-source",
+    heroHeading: "Open Source URL Shortener — Audit, Fork, Self-Host",
+    heroSubheading:
+      "Built with Rust and SvelteKit, licensed under AGPL-3.0. No black boxes, no data-sharing agreements, no vendor dependency.",
+    metaTitle: "Open Source URL Shortener — AGPL-3.0 | Rushomon",
+    metaDescription:
+      "Rushomon is a fully open source URL shortener built with Rust and SvelteKit. Self-host on Cloudflare Workers or use the hosted service. AGPL-3.0 license.",
+    intro:
+      "Most link shorteners — even ones that claim to care about privacy — are proprietary software running on servers you don't control. Rushomon is different: the entire codebase is public on GitHub, licensed under AGPL-3.0. You can read every line, self-host the whole thing, and never worry about a vendor changing terms or going offline.",
+    features: [
+      {
+        title: "Full source on GitHub",
+        body: "The entire Rushomon codebase — Rust backend, SvelteKit frontend, database migrations — is public at github.com/piffio/rushomon."
+      },
+      {
+        title: "AGPL-3.0 license",
+        body: "Modifications must also be open source. If you run a modified version as a network service, you must publish your changes — keeping the ecosystem honest."
+      },
+      {
+        title: "Rust + WebAssembly backend",
+        body: "The backend runs as a Cloudflare Worker compiled from Rust to WebAssembly. Fast, memory-safe, and auditable."
+      },
+      {
+        title: "SvelteKit frontend",
+        body: "The dashboard and landing page are built with SvelteKit and Tailwind CSS. The full frontend source is included."
+      },
+      {
+        title: "Community contributions welcome",
+        body: "Open issues, submit PRs, or fork for your own needs. The project follows standard GitHub contribution workflows."
+      },
+      {
+        title: "No telemetry",
+        body: "Self-hosted instances send no data back to Rushomon. What happens in your Cloudflare account stays in your Cloudflare account."
+      }
+    ],
+    faqs: [
+      {
+        q: "Can I use Rushomon for commercial purposes?",
+        a: "Yes, including for commercial self-hosted deployments. The AGPL-3.0 license requires you to publish modifications if you offer the software as a network service."
+      },
+      {
+        q: "Is the hosted rushomon.cc service the same code as open source?",
+        a: "Yes. rushomon.cc runs the exact same code published on GitHub. No proprietary additions or hidden features."
+      },
+      {
+        q: "Can I fork Rushomon and use a different license?",
+        a: "No. AGPL-3.0 is copyleft — forks and derivative works must also use AGPL-3.0 or a compatible license."
+      },
+      {
+        q: "How do I contribute?",
+        a: "Open a GitHub issue or pull request at github.com/piffio/rushomon. The CONTRIBUTING.md file has setup instructions."
+      }
+    ]
+  },
+  teams: {
+    slug: "teams",
+    heroHeading: "URL Shortener for Teams — Shared Links, Shared Analytics",
+    heroSubheading:
+      "One organization, multiple team members, centralized analytics. Keep everyone's short links in one place.",
+    metaTitle: "URL Shortener for Teams | Rushomon",
+    metaDescription:
+      "Rushomon's Business plan lets teams share a link library, view combined analytics, and manage members under one organization. Self-hostable for enterprises.",
+    intro:
+      "When multiple people on a team are creating short links independently — different tools, different domains, no shared analytics — things get messy fast. Rushomon's organization model puts all team links and analytics in one place, with role-based access, so everyone works from the same source of truth.",
+    features: [
+      {
+        title: "Shared organization",
+        body: "Every link belongs to an organization. Team members see and manage the full shared link library, not just their own."
+      },
+      {
+        title: "Combined analytics",
+        body: "See aggregated click analytics across all team links. Understand which campaigns, channels, and content types drive the most traffic."
+      },
+      {
+        title: "Role-based access",
+        body: "Admins manage members and settings. Regular members create and manage links. Permissions are enforced at the API level."
+      },
+      {
+        title: "Up to 20 team members",
+        body: "Business plan supports up to 20 members per organization — enough for marketing teams, agencies, and mid-size companies."
+      },
+      {
+        title: "10,000 links per month",
+        body: "Business plan supports 10,000 new links per month — no worrying about hitting limits during big campaigns."
+      },
+      {
+        title: "API access for automation",
+        body: "Automate link creation from CI/CD pipelines, marketing tools, or custom scripts using the REST API with Personal Access Tokens."
+      }
+    ],
+    faqs: [
+      {
+        q: "How many team members can share one organization?",
+        a: "Up to 20 members on the Business plan. The Pro plan is optimized for individual use."
+      },
+      {
+        q: "Can team members have different permission levels?",
+        a: "Yes. Organization admins can manage members and billing. Regular members can create and manage links."
+      },
+      {
+        q: "Can we self-host for our enterprise?",
+        a: "Yes. Rushomon is open source and can be self-hosted on your Cloudflare account. Ideal for enterprises with data residency requirements."
+      },
+      {
+        q: "Is there a limit on how many organizations we can create?",
+        a: "Business plan supports up to 3 organizations. Contact us for enterprise needs beyond that."
+      }
+    ]
+  }
+};
+
+export const USE_CASE_SLUGS = Object.keys(USE_CASES);

--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -201,6 +201,16 @@
           >Affero General Public License v3.0.</a
         >
       </p>
+      <p class="mt-2">
+        Built by
+        <a
+          href="https://sergiovisinoni.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-gray-600 hover:text-orange-600 transition-colors"
+          >Sergio Visinoni</a
+        >.
+      </p>
     </div>
   </div>
 </footer>

--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -7,7 +7,7 @@
 
 <footer class="bg-gray-50 border-t border-gray-200 mt-auto">
   <div class="container mx-auto px-4 py-8">
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
+    <div class="grid grid-cols-1 md:grid-cols-5 gap-8">
       <!-- Branding Section -->
       <div class="col-span-1">
         <div class="flex items-center gap-2 mb-4">
@@ -48,6 +48,55 @@
               rel="noopener noreferrer"
               class="text-gray-600 hover:text-orange-600 transition-colors"
               >Self-Hosting Guide</a
+            >
+          </li>
+        </ul>
+      </div>
+
+      <!-- Resources Links -->
+      <div>
+        <h3 class="font-semibold text-gray-900 mb-3">Resources</h3>
+        <ul class="space-y-2 text-sm">
+          <li>
+            <a
+              href="/alternatives/bitly"
+              class="text-gray-600 hover:text-orange-600 transition-colors"
+              >Bitly Alternative</a
+            >
+          </li>
+          <li>
+            <a
+              href="/alternatives/dub"
+              class="text-gray-600 hover:text-orange-600 transition-colors"
+              >Dub Alternative</a
+            >
+          </li>
+          <li>
+            <a
+              href="/alternatives/short-io"
+              class="text-gray-600 hover:text-orange-600 transition-colors"
+              >Short.io Alternative</a
+            >
+          </li>
+          <li>
+            <a
+              href="/use-cases/self-hosted"
+              class="text-gray-600 hover:text-orange-600 transition-colors"
+              >Self-Hosted URL Shortener</a
+            >
+          </li>
+          <li>
+            <a
+              href="/use-cases/open-source"
+              class="text-gray-600 hover:text-orange-600 transition-colors"
+              >Open Source URL Shortener</a
+            >
+          </li>
+          <li>
+            <a
+              href="/use-cases/teams"
+              class="text-gray-600 hover:text-orange-600 transition-colors"
+              >URL Shortener for Teams</a
             >
           </li>
         </ul>

--- a/frontend/src/lib/components/SEO.svelte
+++ b/frontend/src/lib/components/SEO.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-  import { page } from "$app/state";
-  import { browser } from "$app/environment";
-
   interface Props {
     title: string;
     description?: string;
@@ -12,17 +9,12 @@
 
   const props: Props = $props();
 
-  const siteUrl = $derived(
-    browser
-      ? window.location.origin
-      : import.meta.env.PUBLIC_VITE_SITE_URL || "https://rushomon.cc"
-  );
-  const canonicalUrl = $derived(props.canonical || page.url.href);
-  const fullTitle = $derived(`${props.title} – Rushomon`);
+  // Use environment variable or fallback to production URL
+  const siteUrl = import.meta.env.PUBLIC_VITE_SITE_URL || "https://rushomon.cc";
 </script>
 
 <svelte:head>
-  <title>{fullTitle}</title>
+  <title>{props.title} – Rushomon</title>
   {#if props.description}
     <meta name="description" content={props.description} />
   {/if}
@@ -31,28 +23,25 @@
   {/if}
 
   <!-- Canonical URL -->
-  <link rel="canonical" href={canonicalUrl} />
+  <link rel="canonical" href={props.canonical || siteUrl} />
 
   <!-- Open Graph tags -->
   <meta property="og:type" content={props.ogType} />
   <meta property="og:site_name" content="Rushomon" />
-  <meta property="og:title" content={fullTitle} />
+  <meta property="og:title" content={`${props.title} – Rushomon`} />
   {#if props.description}
     <meta property="og:description" content={props.description} />
   {/if}
-  <meta property="og:url" content={canonicalUrl} />
+  <meta property="og:url" content={props.canonical || siteUrl} />
   <meta property="og:image" content={`${siteUrl}/favicon-192x192.png`} />
   <meta property="og:image:width" content="192" />
   <meta property="og:image:height" content="192" />
 
   <!-- Twitter/X Card tags -->
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content={fullTitle} />
+  <meta name="twitter:title" content={`${props.title} – Rushomon`} />
   {#if props.description}
     <meta name="twitter:description" content={props.description} />
   {/if}
   <meta name="twitter:image" content={`${siteUrl}/favicon-192x192.png`} />
-
-  <!-- Sitemap reference for search engines -->
-  <link rel="sitemap" type="application/xml" href={`${siteUrl}/sitemap.xml`} />
 </svelte:head>

--- a/frontend/src/lib/seo/pages.ts
+++ b/frontend/src/lib/seo/pages.ts
@@ -8,6 +8,60 @@ export interface PublicPage {
 export const PUBLIC_PAGES: PublicPage[] = [
   { path: "/", changefreq: "weekly", priority: "1.0", indexable: true },
   { path: "/pricing", changefreq: "monthly", priority: "0.8", indexable: true },
+  {
+    path: "/alternatives/bitly",
+    changefreq: "monthly",
+    priority: "0.8",
+    indexable: true
+  },
+  {
+    path: "/alternatives/dub",
+    changefreq: "monthly",
+    priority: "0.7",
+    indexable: true
+  },
+  {
+    path: "/alternatives/short-io",
+    changefreq: "monthly",
+    priority: "0.7",
+    indexable: true
+  },
+  {
+    path: "/compare/rushomon-vs-bitly",
+    changefreq: "monthly",
+    priority: "0.7",
+    indexable: true
+  },
+  {
+    path: "/compare/rushomon-vs-dub",
+    changefreq: "monthly",
+    priority: "0.7",
+    indexable: true
+  },
+  {
+    path: "/compare/rushomon-vs-short-io",
+    changefreq: "monthly",
+    priority: "0.7",
+    indexable: true
+  },
+  {
+    path: "/use-cases/self-hosted",
+    changefreq: "monthly",
+    priority: "0.7",
+    indexable: true
+  },
+  {
+    path: "/use-cases/open-source",
+    changefreq: "monthly",
+    priority: "0.7",
+    indexable: true
+  },
+  {
+    path: "/use-cases/teams",
+    changefreq: "monthly",
+    priority: "0.6",
+    indexable: true
+  },
   { path: "/report", changefreq: "monthly", priority: "0.6", indexable: true },
   { path: "/terms", changefreq: "yearly", priority: "0.3", indexable: true },
   { path: "/privacy", changefreq: "yearly", priority: "0.3", indexable: true }

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -16,7 +16,10 @@ export const load: LayoutLoad = async ({ url, fetch }) => {
     "/privacy",
     "/report",
     "/login",
-    "/invite"
+    "/invite",
+    "/alternatives",
+    "/compare",
+    "/use-cases"
   ];
   const isPublicRoute =
     url.pathname === "/" ||

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -757,6 +757,27 @@
               <h3 class="font-semibold text-gray-900 mb-1">Self-Hostable</h3>
               <p class="text-gray-600 text-sm">Deploy on Cloudflare Workers.</p>
             </div>
+            <div class="text-center">
+              <div
+                class="w-12 h-12 bg-orange-100 rounded-xl flex items-center justify-center mb-3 mx-auto"
+              >
+                <svg
+                  class="w-6 h-6 text-orange-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
+                  />
+                </svg>
+              </div>
+              <h3 class="font-semibold text-gray-900 mb-1">Your Domain</h3>
+              <p class="text-gray-600 text-sm">Run it on your own domain.</p>
+            </div>
           </div>
 
           <a

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,23 +1,32 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
+  import { authApi } from "$lib/api/auth";
   import Footer from "$lib/components/Footer.svelte";
   import Header from "$lib/components/Header.svelte";
   import SEO from "$lib/components/SEO.svelte";
+  import type { User } from "$lib/types/api";
   import { onMount } from "svelte";
   import type { PageData } from "./$types";
 
-  const { data }: { data: PageData } = $props();
+  const { data: _data }: { data: PageData } = $props();
 
+  let currentUser = $state<User | undefined>(undefined);
   let signupsDisabled = $state(false);
   let navigating = $state(false);
 
-  onMount(() => {
+  onMount(async () => {
     signupsDisabled = page.url.searchParams.get("error") === "signups_disabled";
+    try {
+      const user = await authApi.me();
+      currentUser = user;
+    } catch {
+      currentUser = undefined;
+    }
   });
 
   function handleNavigation() {
-    if (data.user) {
+    if (currentUser) {
       navigating = true;
       goto("/dashboard");
     }
@@ -26,13 +35,13 @@
 
 <svelte:head>
   <SEO
-    title="Rushomon — URL Shortener with Analytics"
-    description="URL shortener with powerful analytics. Free tier available, open source, self-hostable."
+    title="Rushomon - Open Source URL Shortener & Link Analytics"
+    description="Free, open source URL shortener with powerful analytics. Self-hostable on Cloudflare Workers. A better Bitly alternative - no lock-in, your data, your domain."
   />
 </svelte:head>
 
 <div class="min-h-screen bg-white flex flex-col">
-  <Header user={data.user} currentPage="landing" />
+  <Header user={currentUser} currentPage="landing" />
 
   <!-- Hero Section -->
   <main class="flex-1">
@@ -70,8 +79,8 @@
 
           <!-- CTA Button -->
           <a
-            href={data.user ? "/dashboard" : "/login"}
-            onclick={data.user ? handleNavigation : undefined}
+            href={currentUser ? "/dashboard" : "/login"}
+            onclick={currentUser ? handleNavigation : undefined}
             class="inline-flex items-center gap-3 bg-gradient-to-r from-orange-500 to-orange-600 text-white px-10 py-5 rounded-xl text-lg font-semibold hover:from-orange-600 hover:to-orange-700 transition-all shadow-lg hover:shadow-xl hover:scale-105 transform duration-200 {navigating
               ? 'opacity-70 cursor-not-allowed'
               : ''}"
@@ -93,7 +102,9 @@
                 />
               </svg>
             {:else}
-              {data.user ? "Go to Dashboard" : "Create Your First Link — Free"}
+              {currentUser
+                ? "Go to Dashboard"
+                : "Create Your First Link — Free"}
               <svg
                 class="w-6 h-6"
                 fill="none"
@@ -561,22 +572,6 @@
                   </svg>
                   Advanced analytics
                 </li>
-                <li class="flex items-center gap-3">
-                  <svg
-                    class="w-5 h-5 text-green-500"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
-                  Custom domains
-                </li>
               </ul>
               <a
                 href="/pricing"
@@ -761,27 +756,6 @@
               </div>
               <h3 class="font-semibold text-gray-900 mb-1">Self-Hostable</h3>
               <p class="text-gray-600 text-sm">Deploy on Cloudflare Workers.</p>
-            </div>
-            <div class="text-center">
-              <div
-                class="w-12 h-12 bg-orange-100 rounded-xl flex items-center justify-center mb-3 mx-auto"
-              >
-                <svg
-                  class="w-6 h-6 text-orange-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
-                  />
-                </svg>
-              </div>
-              <h3 class="font-semibold text-gray-900 mb-1">Your Domain</h3>
-              <p class="text-gray-600 text-sm">Use your own custom domain.</p>
             </div>
           </div>
 

--- a/frontend/src/routes/alternatives/[competitor]/+page.svelte
+++ b/frontend/src/routes/alternatives/[competitor]/+page.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+  import { authApi } from "$lib/api/auth";
+  import Footer from "$lib/components/Footer.svelte";
+  import Header from "$lib/components/Header.svelte";
+  import SEO from "$lib/components/SEO.svelte";
+  import type { User } from "$lib/types/api";
+  import { onMount } from "svelte";
+  import type { PageData } from "./$types";
+
+  const { data }: { data: PageData } = $props();
+  const competitor = $derived(data.competitor);
+
+  let currentUser = $state<User | undefined>(undefined);
+
+  onMount(async () => {
+    try {
+      const user = await authApi.me();
+      currentUser = user;
+    } catch {
+      currentUser = undefined;
+    }
+  });
+</script>
+
+<svelte:head>
+  <SEO title={competitor.metaTitle} description={competitor.metaDescription} />
+</svelte:head>
+
+<div class="min-h-screen bg-white flex flex-col">
+  <Header user={currentUser} currentPage="landing" />
+
+  <main class="flex-1">
+    <!-- Hero -->
+    <section class="bg-gradient-to-b from-orange-50 to-white py-20 md:py-28">
+      <div class="container mx-auto px-4 max-w-4xl text-center">
+        <div
+          class="inline-flex items-center gap-2 bg-orange-100 text-orange-700 text-sm font-medium px-4 py-1.5 rounded-full mb-6"
+        >
+          Rushomon vs {competitor.name}
+        </div>
+        <h1
+          class="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight"
+        >
+          {competitor.heroHeading}
+        </h1>
+        <p
+          class="text-xl text-gray-600 mb-10 max-w-2xl mx-auto leading-relaxed"
+        >
+          {competitor.heroSubheading}
+        </p>
+        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+          <a
+            href="/login"
+            class="bg-orange-500 hover:bg-orange-600 text-white px-8 py-3 rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-orange-200"
+          >
+            Get Started Free
+          </a>
+          <a
+            href="/pricing"
+            class="border-2 border-orange-500 text-orange-700 px-8 py-3 rounded-xl font-semibold text-lg hover:bg-orange-50 transition-colors"
+          >
+            View Pricing
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Main pitch -->
+    <section class="py-16">
+      <div class="container mx-auto px-4 max-w-3xl">
+        <p class="text-lg text-gray-700 leading-relaxed text-center">
+          {competitor.mainPitch}
+        </p>
+      </div>
+    </section>
+
+    <!-- Comparison table -->
+    <section class="py-8 pb-20">
+      <div class="container mx-auto px-4 max-w-3xl">
+        <h2
+          class="text-2xl md:text-3xl font-bold text-gray-900 text-center mb-10"
+        >
+          Rushomon vs {competitor.name} — Feature Comparison
+        </h2>
+        <div
+          class="overflow-x-auto rounded-2xl border border-gray-200 shadow-sm"
+        >
+          <table class="w-full text-left">
+            <thead>
+              <tr class="bg-gray-50 border-b border-gray-200">
+                <th class="px-6 py-4 text-sm font-semibold text-gray-600 w-1/2"
+                  >Feature</th
+                >
+                <th class="px-6 py-4 text-sm font-semibold text-orange-600"
+                  >Rushomon</th
+                >
+                <th class="px-6 py-4 text-sm font-semibold text-gray-500"
+                  >{competitor.name}</th
+                >
+              </tr>
+            </thead>
+            <tbody>
+              {#each competitor.features as row, i (row.feature)}
+                <tr class={i % 2 === 0 ? "bg-white" : "bg-gray-50"}>
+                  <td class="px-6 py-4 text-sm font-medium text-gray-700"
+                    >{row.feature}</td
+                  >
+                  <td class="px-6 py-4 text-sm text-gray-900">
+                    {#if row.rushomon === true}
+                      <span class="text-green-600 font-semibold">✓ Yes</span>
+                    {:else if row.rushomon === false || row.rushomon === "No"}
+                      <span class="text-red-500">✗ No</span>
+                    {:else}
+                      <span class="text-green-700">{row.rushomon}</span>
+                    {/if}
+                  </td>
+                  <td class="px-6 py-4 text-sm text-gray-600">
+                    {#if row.competitor === true}
+                      <span class="text-green-600">✓ Yes</span>
+                    {:else if row.competitor === false || row.competitor === "No"}
+                      <span class="text-red-500">✗ No</span>
+                    {:else}
+                      {row.competitor}
+                    {/if}
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- Why Rushomon -->
+    <section class="py-16 bg-gray-50">
+      <div class="container mx-auto px-4 max-w-4xl">
+        <h2
+          class="text-2xl md:text-3xl font-bold text-gray-900 text-center mb-12"
+        >
+          Why Choose Rushomon?
+        </h2>
+        <div class="grid md:grid-cols-3 gap-8">
+          {#each competitor.whyRushomon as item (item.title)}
+            <div
+              class="bg-white rounded-2xl p-6 border border-gray-200 shadow-sm"
+            >
+              <h3 class="text-lg font-semibold text-gray-900 mb-3">
+                {item.title}
+              </h3>
+              <p class="text-gray-600 leading-relaxed">{item.body}</p>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-20">
+      <div class="container mx-auto px-4 max-w-2xl text-center">
+        <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+          Ready to switch from {competitor.name}?
+        </h2>
+
+        <p class="text-lg text-gray-600 mb-8">
+          Start free, no credit card required. Import your existing links or
+          start fresh.
+        </p>
+        <a
+          href="/login"
+          class="inline-block bg-orange-500 hover:bg-orange-600 text-white px-10 py-4 rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-orange-200"
+        >
+          Get Started Free
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <Footer />
+</div>

--- a/frontend/src/routes/alternatives/[competitor]/+page.ts
+++ b/frontend/src/routes/alternatives/[competitor]/+page.ts
@@ -1,0 +1,18 @@
+import { error } from "@sveltejs/kit";
+import { COMPETITORS, COMPETITOR_SLUGS } from "../../../config/competitors";
+import type { PageLoad } from "./$types";
+
+export const prerender = true;
+export const ssr = true;
+
+export function entries() {
+  return COMPETITOR_SLUGS.map((slug: string) => ({ competitor: slug }));
+}
+
+export const load: PageLoad = async ({ params }) => {
+  const competitor = COMPETITORS[params.competitor];
+  if (!competitor) {
+    error(404, "Not found");
+  }
+  return { competitor };
+};

--- a/frontend/src/routes/compare/[slug]/+page.svelte
+++ b/frontend/src/routes/compare/[slug]/+page.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import { authApi } from "$lib/api/auth";
+  import Footer from "$lib/components/Footer.svelte";
+  import Header from "$lib/components/Header.svelte";
+  import SEO from "$lib/components/SEO.svelte";
+  import type { User } from "$lib/types/api";
+  import { onMount } from "svelte";
+  import type { PageData } from "./$types";
+
+  const { data }: { data: PageData } = $props();
+  const competitor = $derived(data.competitor);
+
+  let currentUser = $state<User | undefined>(undefined);
+
+  onMount(async () => {
+    try {
+      const user = await authApi.me();
+      currentUser = user;
+    } catch {
+      currentUser = undefined;
+    }
+  });
+</script>
+
+<svelte:head>
+  <SEO title={competitor.metaTitle} description={competitor.metaDescription} />
+</svelte:head>
+
+<div class="min-h-screen bg-white flex flex-col">
+  <Header user={currentUser} currentPage="landing" />
+
+  <main class="flex-1">
+    <!-- Hero -->
+    <section class="bg-gradient-to-b from-orange-50 to-white py-20 md:py-28">
+      <div class="container mx-auto px-4 max-w-4xl text-center">
+        <div
+          class="inline-flex items-center gap-2 bg-orange-100 text-orange-700 text-sm font-medium px-4 py-1.5 rounded-full mb-6"
+        >
+          Rushomon vs {competitor.name}
+        </div>
+        <h1
+          class="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight"
+        >
+          Rushomon vs {competitor.name}
+        </h1>
+        <p
+          class="text-xl text-gray-600 mb-10 max-w-2xl mx-auto leading-relaxed"
+        >
+          {competitor.heroSubheading}
+        </p>
+        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+          <a
+            href="/login"
+            class="bg-orange-500 hover:bg-orange-600 text-white px-8 py-3 rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-orange-200"
+          >
+            Get Started Free
+          </a>
+          <a
+            href="/pricing"
+            class="border-2 border-orange-500 text-orange-700 px-8 py-3 rounded-xl font-semibold text-lg hover:bg-orange-50 transition-colors"
+          >
+            View Pricing
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Main pitch -->
+    <section class="py-16">
+      <div class="container mx-auto px-4 max-w-3xl">
+        <p class="text-lg text-gray-700 leading-relaxed text-center">
+          {competitor.mainPitch}
+        </p>
+      </div>
+    </section>
+
+    <!-- Comparison table -->
+    <section class="py-8 pb-20">
+      <div class="container mx-auto px-4 max-w-3xl">
+        <h2
+          class="text-2xl md:text-3xl font-bold text-gray-900 text-center mb-10"
+        >
+          Rushomon vs {competitor.name} — Head-to-Head
+        </h2>
+        <div
+          class="overflow-x-auto rounded-2xl border border-gray-200 shadow-sm"
+        >
+          <table class="w-full text-left">
+            <thead>
+              <tr class="bg-gray-50 border-b border-gray-200">
+                <th class="px-6 py-4 text-sm font-semibold text-gray-600 w-1/2"
+                  >Feature</th
+                >
+                <th class="px-6 py-4 text-sm font-semibold text-orange-600"
+                  >Rushomon</th
+                >
+                <th class="px-6 py-4 text-sm font-semibold text-gray-500"
+                  >{competitor.name}</th
+                >
+              </tr>
+            </thead>
+            <tbody>
+              {#each competitor.features as row, i (row.feature)}
+                <tr class={i % 2 === 0 ? "bg-white" : "bg-gray-50"}>
+                  <td class="px-6 py-4 text-sm font-medium text-gray-700"
+                    >{row.feature}</td
+                  >
+                  <td class="px-6 py-4 text-sm text-gray-900">
+                    {#if row.rushomon === true}
+                      <span class="text-green-600 font-semibold">✓ Yes</span>
+                    {:else if row.rushomon === false || row.rushomon === "No"}
+                      <span class="text-red-500">✗ No</span>
+                    {:else}
+                      <span class="text-green-700">{row.rushomon}</span>
+                    {/if}
+                  </td>
+                  <td class="px-6 py-4 text-sm text-gray-600">
+                    {#if row.competitor === true}
+                      <span class="text-green-600">✓ Yes</span>
+                    {:else if row.competitor === false || row.competitor === "No"}
+                      <span class="text-red-500">✗ No</span>
+                    {:else}
+                      {row.competitor}
+                    {/if}
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- Why Rushomon -->
+    <section class="py-16 bg-gray-50">
+      <div class="container mx-auto px-4 max-w-4xl">
+        <h2
+          class="text-2xl md:text-3xl font-bold text-gray-900 text-center mb-12"
+        >
+          Why Rushomon Wins
+        </h2>
+        <div class="grid md:grid-cols-3 gap-8">
+          {#each competitor.whyRushomon as item (item.title)}
+            <div
+              class="bg-white rounded-2xl p-6 border border-gray-200 shadow-sm"
+            >
+              <h3 class="text-lg font-semibold text-gray-900 mb-3">
+                {item.title}
+              </h3>
+              <p class="text-gray-600 leading-relaxed">{item.body}</p>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-20">
+      <div class="container mx-auto px-4 max-w-2xl text-center">
+        <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+          Try Rushomon for Free
+        </h2>
+        <p class="text-lg text-gray-600 mb-8">
+          Start free, no credit card required. Import your existing links or
+          start fresh.
+        </p>
+        <a
+          href="/login"
+          class="inline-block bg-orange-500 hover:bg-orange-600 text-white px-10 py-4 rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-orange-200"
+        >
+          Get Started Free
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <Footer />
+</div>

--- a/frontend/src/routes/compare/[slug]/+page.ts
+++ b/frontend/src/routes/compare/[slug]/+page.ts
@@ -1,0 +1,24 @@
+import { error } from "@sveltejs/kit";
+import { COMPETITORS, COMPETITOR_SLUGS } from "../../../config/competitors";
+import type { PageLoad } from "./$types";
+
+export const prerender = true;
+export const ssr = true;
+
+export function entries() {
+  return COMPETITOR_SLUGS.map((slug: string) => ({
+    slug: `rushomon-vs-${slug}`
+  }));
+}
+
+export const load: PageLoad = async ({ params }) => {
+  const match = params.slug.match(/^rushomon-vs-(.+)$/);
+  if (!match) {
+    error(404, "Not found");
+  }
+  const competitor = COMPETITORS[match[1]];
+  if (!competitor) {
+    error(404, "Not found");
+  }
+  return { competitor };
+};

--- a/frontend/src/routes/use-cases/[slug]/+page.svelte
+++ b/frontend/src/routes/use-cases/[slug]/+page.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import { authApi } from "$lib/api/auth";
+  import Footer from "$lib/components/Footer.svelte";
+  import Header from "$lib/components/Header.svelte";
+  import SEO from "$lib/components/SEO.svelte";
+  import type { User } from "$lib/types/api";
+  import { onMount } from "svelte";
+  import type { PageData } from "./$types";
+
+  const { data }: { data: PageData } = $props();
+  const useCase = $derived(data.useCase);
+
+  let currentUser = $state<User | undefined>(undefined);
+
+  onMount(async () => {
+    try {
+      const user = await authApi.me();
+      currentUser = user;
+    } catch {
+      currentUser = undefined;
+    }
+  });
+</script>
+
+<svelte:head>
+  <SEO title={useCase.metaTitle} description={useCase.metaDescription} />
+</svelte:head>
+
+<div class="min-h-screen bg-white flex flex-col">
+  <Header user={currentUser} currentPage="landing" />
+
+  <main class="flex-1">
+    <!-- Hero -->
+    <section class="bg-gradient-to-b from-orange-50 to-white py-20 md:py-28">
+      <div class="container mx-auto px-4 max-w-4xl text-center">
+        <h1
+          class="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight"
+        >
+          {useCase.heroHeading}
+        </h1>
+        <p
+          class="text-xl text-gray-600 mb-10 max-w-2xl mx-auto leading-relaxed"
+        >
+          {useCase.heroSubheading}
+        </p>
+        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+          <a
+            href="/login"
+            class="bg-orange-500 hover:bg-orange-600 text-white px-8 py-3 rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-orange-200"
+          >
+            Get Started Free
+          </a>
+          <a
+            href="https://github.com/piffio/rushomon/blob/main/docs/SELF_HOSTING.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="border-2 border-orange-500 text-orange-700 px-8 py-3 rounded-xl font-semibold text-lg hover:bg-orange-50 transition-colors"
+          >
+            Self-Hosting Guide
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Intro -->
+    <section class="py-16">
+      <div class="container mx-auto px-4 max-w-3xl">
+        <p class="text-lg text-gray-700 leading-relaxed text-center">
+          {useCase.intro}
+        </p>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section class="py-8 pb-20 bg-gray-50">
+      <div class="container mx-auto px-4 max-w-5xl">
+        <h2
+          class="text-2xl md:text-3xl font-bold text-gray-900 text-center mb-12"
+        >
+          Why Rushomon?
+        </h2>
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {#each useCase.features as feature (feature.title)}
+            <div
+              class="bg-white rounded-2xl p-6 border border-gray-200 shadow-sm"
+            >
+              <h3 class="text-lg font-semibold text-gray-900 mb-2">
+                {feature.title}
+              </h3>
+              <p class="text-gray-600 leading-relaxed text-sm">
+                {feature.body}
+              </p>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="py-20">
+      <div class="container mx-auto px-4 max-w-3xl">
+        <h2
+          class="text-2xl md:text-3xl font-bold text-gray-900 text-center mb-12"
+        >
+          Frequently Asked Questions
+        </h2>
+        <div class="space-y-6">
+          {#each useCase.faqs as faq (faq.q)}
+            <div class="border border-gray-200 rounded-2xl p-6">
+              <h3 class="text-base font-semibold text-gray-900 mb-2">
+                {faq.q}
+              </h3>
+              <p class="text-gray-600 leading-relaxed">{faq.a}</p>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-16 bg-orange-50">
+      <div class="container mx-auto px-4 max-w-2xl text-center">
+        <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+          Ready to get started?
+        </h2>
+        <p class="text-lg text-gray-600 mb-8">
+          Free tier available. No credit card required.
+        </p>
+        <a
+          href="/login"
+          class="inline-block bg-orange-500 hover:bg-orange-600 text-white px-10 py-4 rounded-xl font-semibold text-lg transition-colors shadow-lg shadow-orange-200"
+        >
+          Get Started Free
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <Footer />
+</div>

--- a/frontend/src/routes/use-cases/[slug]/+page.ts
+++ b/frontend/src/routes/use-cases/[slug]/+page.ts
@@ -1,0 +1,18 @@
+import { USE_CASES, USE_CASE_SLUGS } from "../../../config/use-cases";
+import { error } from "@sveltejs/kit";
+import type { PageLoad } from "./$types";
+
+export const prerender = true;
+export const ssr = true;
+
+export function entries() {
+  return USE_CASE_SLUGS.map((slug: string) => ({ slug }));
+}
+
+export const load: PageLoad = async ({ params }) => {
+  const useCase = USE_CASES[params.slug];
+  if (!useCase) {
+    error(404, "Not found");
+  }
+  return { useCase };
+};

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -12,7 +12,23 @@ const config = {
     }),
     prerender: {
       origin: process.env.PUBLIC_VITE_SITE_URL || "https://rushomon.cc",
-      entries: ["/", "/pricing", "/terms", "/privacy", "/report", "/login"], // Explicitly prerender key routes
+      entries: [
+        "/",
+        "/pricing",
+        "/terms",
+        "/privacy",
+        "/report",
+        "/login",
+        "/alternatives/bitly",
+        "/alternatives/dub",
+        "/alternatives/short-io",
+        "/compare/rushomon-vs-bitly",
+        "/compare/rushomon-vs-dub",
+        "/compare/rushomon-vs-short-io",
+        "/use-cases/self-hosted",
+        "/use-cases/open-source",
+        "/use-cases/teams"
+      ], // Explicitly prerender key routes
       handleUnseenRoutes: "ignore" // Don't fail if routes are not found during crawling
     }
   }


### PR DESCRIPTION
- Create competitor comparison pages (/alternatives/[competitor]) for Bitly, Dub.co, Short.io
- Create comparison pages (/compare/[slug]) with feature-by-feature breakdowns
- Create use case pages (/use-cases/[slug]) for self-hosting, open-source, teams
- Add config files (competitors.ts, use-cases.ts) with accurate pricing data from official sources
- Add footer Resources section with links to all new SEO pages
- Update sitemap generation to include new routes
- Update SEO component to use environment variable for siteUrl
- Add new routes to prerender entries in svelte.config.js

Closes #342 