### PR TITLE
feat: monthly email statistics summary

### DIFF
--- a/.github/workflows/deploy-ephemeral.yml
+++ b/.github/workflows/deploy-ephemeral.yml
@@ -250,7 +250,7 @@ jobs:
           # NOTE: Custom domain polling is done manually via admin panel
           # in ephemeral/staging due to cron trigger limits.
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *"]
+          crons = ["0 0 * * *", "0 4 * * *", "0 8 2 * *"]
 
           [[d1_databases]]
           binding = "rushomon"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -74,7 +74,7 @@ jobs:
           # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
           # - "*/15 * * * *" = every 15 min (custom domain status polling)
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *", "*/15 * * * *"]
+          crons = ["0 0 * * *", "0 4 * * *", "*/15 * * * *", "0 8 2 * *"]
 
           [[d1_databases]]
           binding = "rushomon"
@@ -230,7 +230,7 @@ jobs:
           # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
           # - "*/15 * * * *" = every 15 min (custom domain status polling)
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *", "*/15 * * * *"]
+          crons = ["0 0 * * *", "0 4 * * *", "*/15 * * * *", "0 8 2 * *"]
 
           [[d1_databases]]
           binding = "rushomon"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -75,7 +75,7 @@ jobs:
           # - "0 0 * * *" = midnight UTC daily (subscription downgrade)
           # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *"]
+          crons = ["0 0 * * *", "0 4 * * *", "0 8 2 * *"]
 
           [[d1_databases]]
           binding = "rushomon"
@@ -176,7 +176,7 @@ jobs:
           # - "0 0 * * *" = midnight UTC daily (subscription downgrade)
           # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *"]
+          crons = ["0 0 * * *", "0 4 * * *", "0 8 2 * *"]
 
           [[d1_databases]]
           binding = "rushomon"

--- a/docs/openapi/main.json
+++ b/docs/openapi/main.json
@@ -11,7 +11,7 @@
       "name": "AGPL-3.0",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"
     },
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "servers": [
     {

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -599,6 +599,22 @@ export const adminApi = {
   },
 
   /**
+   * Trigger the monthly stats email cron job (admin only)
+   * @returns Object with sent and error counts
+   */
+  async triggerCronMonthlyStats(): Promise<{
+    sent: number;
+    errors: number;
+  }> {
+    return apiClient.request<{
+      sent: number;
+      errors: number;
+    }>("/api/admin/cron/trigger-monthly-stats", {
+      method: "POST"
+    });
+  },
+
+  /**
    * List all API keys instance-wide (admin only)
    */
   async listApiKeys(

--- a/frontend/src/lib/api/notifications.ts
+++ b/frontend/src/lib/api/notifications.ts
@@ -1,0 +1,27 @@
+import { apiClient } from "./client";
+import type { NotificationPreferences } from "$lib/types/api";
+
+export const notificationsApi = {
+  /**
+   * Get the current user's email notification preferences.
+   * Missing preferences default to all-enabled on the backend.
+   */
+  async getPreferences(): Promise<NotificationPreferences> {
+    return apiClient.get<NotificationPreferences>(
+      "/api/notifications/preferences"
+    );
+  },
+
+  /**
+   * Update one or more notification preference flags.
+   * Omitted fields retain their current values.
+   */
+  async updatePreferences(
+    prefs: Partial<NotificationPreferences>
+  ): Promise<NotificationPreferences> {
+    return apiClient.patch<NotificationPreferences>(
+      "/api/notifications/preferences",
+      prefs
+    );
+  }
+};

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -289,6 +289,13 @@ export interface AdminLinksResponse {
   limit: number;
 }
 
+// ─── Notification Preference Types ───────────────────────────────────────────
+
+export interface NotificationPreferences {
+  /** Receive a monthly stats summary email at the start of each month. Defaults to true. */
+  email_monthly_stats: boolean;
+}
+
 // ─── Org Management Types ─────────────────────────────────────────────────────
 
 export interface OrgWithRole {

--- a/frontend/src/routes/admin/settings/+page.svelte
+++ b/frontend/src/routes/admin/settings/+page.svelte
@@ -23,6 +23,13 @@
   } | null>(null);
   let showCronResult = $state(false);
 
+  let monthlyStatsLoading = $state(false);
+  let monthlyStatsResult = $state<{
+    sent: number;
+    errors: number;
+  } | null>(null);
+  let showMonthlyStatsResult = $state(false);
+
   let discounts = $state<Discount[]>([]);
   let discountsLoading = $state(false);
   let discountsError = $state("");
@@ -455,6 +462,20 @@
       cronLoading = false;
     }
   }
+
+  async function triggerMonthlyStats() {
+    try {
+      monthlyStatsLoading = true;
+      const result = await adminApi.triggerCronMonthlyStats();
+      monthlyStatsResult = result;
+      showMonthlyStatsResult = true;
+    } catch (err) {
+      console.error("Failed to trigger monthly stats:", err);
+      showToastMessage("Failed to trigger monthly stats");
+    } finally {
+      monthlyStatsLoading = false;
+    }
+  }
 </script>
 
 <div class="settings-page">
@@ -751,7 +772,6 @@
             </button>
           </div>
         </div>
-
         {#if showCronResult && cronResult}
           <div
             class="cron-result {cronResult.errors > 0
@@ -781,6 +801,68 @@
             {:else}
               <p class="success-message">
                 All expired subscriptions were processed successfully.
+              </p>
+            {/if}
+          </div>
+        {/if}
+      </div>
+
+      <!-- Email Notifications Section -->
+      <div class="pricing-section">
+        <h2 class="pricing-section-header">📧 Email Notifications</h2>
+        <p class="pricing-section-description">
+          Trigger email jobs for user notifications
+        </p>
+      </div>
+
+      <!-- Monthly Stats Email Trigger -->
+      <div class="setting-card">
+        <div class="setting-content">
+          <div class="setting-info">
+            <h3>Monthly stats email</h3>
+            <p class="setting-description">
+              Manually trigger the monthly statistics summary email job. This
+              normally runs automatically on day 2 of each month at 8 AM UTC.
+            </p>
+          </div>
+          <div class="setting-control">
+            <button
+              class="btn btn-primary"
+              onclick={triggerMonthlyStats}
+              disabled={monthlyStatsLoading}
+            >
+              {#if monthlyStatsLoading}
+                Sending...
+              {:else}
+                Send Now
+              {/if}
+            </button>
+          </div>
+        </div>
+        {#if showMonthlyStatsResult && monthlyStatsResult}
+          <div
+            class="cron-result {monthlyStatsResult.errors > 0
+              ? 'has-errors'
+              : 'success'}"
+          >
+            <h4>Email Results</h4>
+            <div class="result-stats">
+              <div class="stat">
+                <span class="stat-value">{monthlyStatsResult.sent}</span>
+                <span class="stat-label">Sent</span>
+              </div>
+              <div class="stat">
+                <span class="stat-value">{monthlyStatsResult.errors}</span>
+                <span class="stat-label">Errors</span>
+              </div>
+            </div>
+            {#if monthlyStatsResult.errors > 0}
+              <p class="error-message">
+                Some emails failed to send. Check the logs for details.
+              </p>
+            {:else}
+              <p class="success-message">
+                Monthly stats emails sent successfully.
               </p>
             {/if}
           </div>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -2,10 +2,11 @@
   import type { BillingStatus } from "$lib/api/billing";
   import { billingApi } from "$lib/api/billing";
   import { apiClient } from "$lib/api/client";
+  import { notificationsApi } from "$lib/api/notifications";
   import { orgsApi } from "$lib/api/orgs";
   import { apiKeysApi, type ApiKey } from "$lib/api/settings";
   import Header from "$lib/components/Header.svelte";
-  import type { OrgWithRole } from "$lib/types/api";
+  import type { NotificationPreferences, OrgWithRole } from "$lib/types/api";
   import type { PageData } from "./$types";
 
   const { data }: { data: PageData } = $props();
@@ -37,6 +38,16 @@
   let isCreatingKey = $state(false);
   let createError = $state<string | null>(null);
   let copySuccess = $state(false);
+
+  // Email notification feature flag (from public settings)
+  let emailNotificationsEnabled = $state(false);
+
+  // Notification preferences
+  let notifPrefs = $state<NotificationPreferences>({
+    email_monthly_stats: true
+  });
+  let notifPrefsLoading = $state(true);
+  let notifSaving = $state(false);
 
   // Helper for version API URL
   const versionApiUrl = `${apiClient["baseUrl"]}/api/version`;
@@ -81,6 +92,26 @@
       .catch(() => {})
       .finally(() => {
         keysLoading = false;
+      });
+
+    // Fetch public settings to determine if email notifications feature is enabled
+    apiClient
+      .get<{ email_notifications_enabled?: boolean }>("/api/settings")
+      .then((s) => {
+        emailNotificationsEnabled = s.email_notifications_enabled ?? false;
+      })
+      .catch(() => {});
+
+    // Fetch notification preferences (only meaningful when feature is enabled,
+    // but we pre-load regardless so there's no flicker when the flag arrives)
+    notificationsApi
+      .getPreferences()
+      .then((prefs) => {
+        notifPrefs = prefs;
+      })
+      .catch(() => {})
+      .finally(() => {
+        notifPrefsLoading = false;
       });
   });
 
@@ -152,6 +183,24 @@
       setTimeout(() => {
         copySuccess = false;
       }, 3000);
+    }
+  }
+
+  async function handleToggleNotifPref(
+    key: keyof NotificationPreferences,
+    value: boolean
+  ) {
+    notifSaving = true;
+    try {
+      const updated = await notificationsApi.updatePreferences({
+        [key]: value
+      });
+      notifPrefs = updated;
+    } catch {
+      // Revert optimistic update on failure
+      notifPrefs = { ...notifPrefs, [key]: !value };
+    } finally {
+      notifSaving = false;
     }
   }
 </script>
@@ -352,6 +401,75 @@
                   </button>
                 </li>
               {/each}
+            </ul>
+          {/if}
+        </div>
+      {/if}
+
+      <!-- Email Notifications Section -->
+      {#if emailNotificationsEnabled}
+        <div class="mt-6 bg-white rounded-2xl border-2 border-gray-200 p-6">
+          <h3 class="font-semibold text-gray-900 mb-1">Email Notifications</h3>
+          <p class="text-xs text-gray-500 mb-4">
+            Choose which emails you'd like to receive from Rushomon.
+          </p>
+
+          {#if notifPrefsLoading}
+            <div class="flex items-center gap-2 text-sm text-gray-500 py-2">
+              <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                ></circle>
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
+              </svg>
+              Loading preferences...
+            </div>
+          {:else}
+            <ul class="divide-y divide-gray-100">
+              <!-- Monthly statistics -->
+              <li
+                class="flex items-start justify-between py-4 first:pt-0 last:pb-0"
+              >
+                <div class="flex-1 pr-4">
+                  <p class="text-sm font-medium text-gray-900">
+                    Monthly statistics summary
+                  </p>
+                  <p class="text-xs text-gray-500 mt-0.5">
+                    Receive a monthly recap of your link performance at the
+                    start of each month.
+                  </p>
+                </div>
+                <!-- Toggle switch -->
+                <button
+                  role="switch"
+                  aria-checked={notifPrefs.email_monthly_stats}
+                  disabled={notifSaving}
+                  onclick={() =>
+                    handleToggleNotifPref(
+                      "email_monthly_stats",
+                      !notifPrefs.email_monthly_stats
+                    )}
+                  class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed {notifPrefs.email_monthly_stats
+                    ? 'bg-orange-500'
+                    : 'bg-gray-200'}"
+                >
+                  <span class="sr-only">Monthly statistics email</span>
+                  <span
+                    class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out {notifPrefs.email_monthly_stats
+                      ? 'translate-x-5'
+                      : 'translate-x-0'}"
+                  ></span>
+                </button>
+              </li>
             </ul>
           {/if}
         </div>

--- a/migrations/0033_notification_preferences.sql
+++ b/migrations/0033_notification_preferences.sql
@@ -1,0 +1,11 @@
+-- Migration 0033: User notification preferences
+--
+-- Stores per-user email notification opt-in/out flags.
+-- Missing row = opted in by default (handled in the repository layer).
+-- New notification types should be added as additional INTEGER columns here.
+
+CREATE TABLE notification_preferences (
+    user_id TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    email_monthly_stats INTEGER NOT NULL DEFAULT 1,
+    updated_at INTEGER NOT NULL
+) STRICT;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@ pub mod billing;
 pub mod domains;
 pub mod keys;
 pub mod links;
+pub mod notifications;
 pub mod orgs;
 pub mod reports;
 pub mod router;

--- a/src/api/notifications/mod.rs
+++ b/src/api/notifications/mod.rs
@@ -1,0 +1,143 @@
+/// Notification preference API handlers
+///
+/// GET  /api/notifications/preferences  — return the current user's preferences
+/// PATCH /api/notifications/preferences — update the current user's preferences
+/// POST /api/admin/cron/trigger-monthly-stats — manually trigger the monthly stats email job
+use crate::auth::{authenticate_request, require_admin};
+use crate::repositories::notification_preferences_repository::{
+    NotificationPreferences, NotificationPreferencesRepository,
+};
+use serde::Deserialize;
+use worker::*;
+
+#[utoipa::path(
+    get,
+    path = "/api/notifications/preferences",
+    tag = "Notifications",
+    summary = "Get notification preferences",
+    description = "Returns the current user's email notification preferences. Missing preferences default to all-enabled.",
+    responses(
+        (status = 200, description = "Notification preferences"),
+        (status = 401, description = "Unauthorized"),
+    ),
+    security(
+        ("Bearer" = []),
+        ("session_cookie" = [])
+    )
+)]
+pub async fn handle_get_notification_preferences(
+    req: Request,
+    ctx: RouteContext<()>,
+) -> Result<Response> {
+    let user_ctx = match authenticate_request(&req, &ctx).await {
+        Ok(c) => c,
+        Err(e) => return Ok(e.into_response()),
+    };
+
+    let db = ctx.env.get_binding::<worker::d1::D1Database>("rushomon")?;
+    let prefs = NotificationPreferencesRepository::new()
+        .get_by_user_id(&db, &user_ctx.user_id)
+        .await?;
+
+    Response::from_json(&prefs)
+}
+
+#[derive(Deserialize)]
+pub struct UpdateNotificationPreferencesRequest {
+    pub email_monthly_stats: Option<bool>,
+}
+
+#[utoipa::path(
+    patch,
+    path = "/api/notifications/preferences",
+    tag = "Notifications",
+    summary = "Update notification preferences",
+    description = "Updates one or more email notification preference flags for the authenticated user.",
+    request_body(
+        content = inline(serde_json::Value),
+        description = r#"Fields to update, e.g. `{"email_monthly_stats": false}`"#
+    ),
+    responses(
+        (status = 200, description = "Updated preferences"),
+        (status = 400, description = "Invalid request body"),
+        (status = 401, description = "Unauthorized"),
+    ),
+    security(
+        ("Bearer" = []),
+        ("session_cookie" = [])
+    )
+)]
+pub async fn handle_update_notification_preferences(
+    mut req: Request,
+    ctx: RouteContext<()>,
+) -> Result<Response> {
+    let user_ctx = match authenticate_request(&req, &ctx).await {
+        Ok(c) => c,
+        Err(e) => return Ok(e.into_response()),
+    };
+
+    let body: UpdateNotificationPreferencesRequest = match req.json().await {
+        Ok(b) => b,
+        Err(_) => return Response::error("Invalid request body", 400),
+    };
+
+    let db = ctx.env.get_binding::<worker::d1::D1Database>("rushomon")?;
+    let repo = NotificationPreferencesRepository::new();
+
+    // Load existing (or default) preferences, then apply the patch
+    let current = repo.get_by_user_id(&db, &user_ctx.user_id).await?;
+
+    let updated = NotificationPreferences {
+        email_monthly_stats: body
+            .email_monthly_stats
+            .unwrap_or(current.email_monthly_stats),
+    };
+
+    let saved = repo.upsert(&db, &user_ctx.user_id, &updated).await?;
+    Response::from_json(&saved)
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/cron/trigger-monthly-stats",
+    tag = "Admin",
+    summary = "Trigger monthly stats email job",
+    description = "Manually triggers the monthly statistics summary email job. Sends emails to all opted-in users.",
+    responses(
+        (status = 200, description = "Email job completed"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Admin required"),
+    ),
+    security(("Bearer" = []), ("session_cookie" = []))
+)]
+pub async fn handle_cron_trigger_monthly_stats(
+    req: Request,
+    ctx: RouteContext<()>,
+) -> Result<Response> {
+    let user_ctx = match authenticate_request(&req, &ctx).await {
+        Ok(c) => c,
+        Err(e) => return Ok(e.into_response()),
+    };
+
+    if let Err(e) = require_admin(&user_ctx) {
+        return Ok(e.into_response());
+    }
+
+    let db = match ctx.env.get_binding::<D1Database>("rushomon") {
+        Ok(db) => db,
+        Err(e) => {
+            console_error!("[cron-trigger] DB binding unavailable: {}", e);
+            return Response::error("Service temporarily unavailable", 503);
+        }
+    };
+
+    console_log!("[cron-trigger] Manually triggering monthly stats email job");
+    let (sent, errors) =
+        crate::services::email_notification_service::send_monthly_stats_to_all_users(&db, &ctx.env)
+            .await;
+
+    Response::from_json(&serde_json::json!({
+        "sent": sent,
+        "errors": errors
+    }))
+}

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -17,6 +17,15 @@ pub async fn run(req: Request, env: Env, is_frontend_domain: bool) -> Result<Res
     let router = Router::new();
 
     router
+        // Notification preference routes (must come before catch-all /:code)
+        .get_async(
+            "/api/notifications/preferences",
+            crate::api::notifications::handle_get_notification_preferences,
+        )
+        .patch_async(
+            "/api/notifications/preferences",
+            crate::api::notifications::handle_update_notification_preferences,
+        )
         // Public redirect routes - must come first to catch short codes
         .get_async("/:code", move |req, route_ctx| async move {
             let code = route_ctx
@@ -380,6 +389,10 @@ pub async fn run(req: Request, env: Env, is_frontend_domain: bool) -> Result<Res
         .post_async(
             "/api/admin/cron/trigger-downgrade",
             crate::api::billing::handle_cron_trigger_downgrade,
+        )
+        .post_async(
+            "/api/admin/cron/trigger-monthly-stats",
+            crate::api::notifications::handle_cron_trigger_monthly_stats,
         )
         .post_async(
             "/api/admin/billing-accounts/:id/reset",

--- a/src/api/settings/public.rs
+++ b/src/api/settings/public.rs
@@ -18,6 +18,6 @@ use worker::*;
 pub async fn handle_get_public_settings(_req: Request, ctx: RouteContext<()>) -> Result<Response> {
     let db = ctx.env.get_binding::<worker::d1::D1Database>("rushomon")?;
     let settings_service = SettingsService::new();
-    let public_settings = settings_service.get_public_settings(&db).await?;
+    let public_settings = settings_service.get_public_settings(&db, &ctx.env).await?;
     Response::from_json(&public_settings)
 }

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -20,6 +20,7 @@ pub mod billing_repository;
 pub mod blacklist_repository;
 pub mod custom_domain_repository;
 pub mod link_repository;
+pub mod notification_preferences_repository;
 pub mod org_repository;
 pub mod product_repository;
 pub mod report_repository;

--- a/src/repositories/notification_preferences_repository.rs
+++ b/src/repositories/notification_preferences_repository.rs
@@ -1,0 +1,140 @@
+/// Notification Preferences Repository
+///
+/// Data access layer for per-user email notification opt-in/out flags.
+/// A missing row in `notification_preferences` is treated as fully opted-in
+/// (all notifications enabled by default).
+use crate::utils::now_timestamp;
+use serde::{Deserialize, Serialize};
+use worker::Result;
+use worker::d1::D1Database;
+
+/// User notification preferences.
+/// All fields default to `true` (opted in) if no row exists.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationPreferences {
+    pub email_monthly_stats: bool,
+}
+
+impl Default for NotificationPreferences {
+    fn default() -> Self {
+        Self {
+            email_monthly_stats: true,
+        }
+    }
+}
+
+/// A user record enriched with the data needed to send notifications.
+#[derive(Debug, Clone)]
+pub struct UserForNotification {
+    pub user_id: String,
+    pub email: String,
+    pub name: Option<String>,
+}
+
+pub struct NotificationPreferencesRepository;
+
+impl NotificationPreferencesRepository {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Get notification preferences for a user.
+    /// Returns defaults (all enabled) if no row exists.
+    pub async fn get_by_user_id(
+        &self,
+        db: &D1Database,
+        user_id: &str,
+    ) -> Result<NotificationPreferences> {
+        let result = db
+            .prepare(
+                "SELECT email_monthly_stats
+                 FROM notification_preferences
+                 WHERE user_id = ?1",
+            )
+            .bind(&[user_id.into()])?
+            .first::<serde_json::Value>(None)
+            .await?;
+
+        match result {
+            Some(row) => {
+                let email_monthly_stats = row["email_monthly_stats"]
+                    .as_f64()
+                    .map(|v| v != 0.0)
+                    .unwrap_or(true);
+                Ok(NotificationPreferences {
+                    email_monthly_stats,
+                })
+            }
+            // No row → return defaults (all opted in)
+            None => Ok(NotificationPreferences::default()),
+        }
+    }
+
+    /// Upsert notification preferences for a user.
+    pub async fn upsert(
+        &self,
+        db: &D1Database,
+        user_id: &str,
+        prefs: &NotificationPreferences,
+    ) -> Result<NotificationPreferences> {
+        let now = now_timestamp();
+        db.prepare(
+            "INSERT INTO notification_preferences (user_id, email_monthly_stats, updated_at)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(user_id) DO UPDATE SET
+                 email_monthly_stats = excluded.email_monthly_stats,
+                 updated_at = excluded.updated_at",
+        )
+        .bind(&[
+            user_id.into(),
+            (if prefs.email_monthly_stats {
+                1_f64
+            } else {
+                0_f64
+            })
+            .into(),
+            (now as f64).into(),
+        ])?
+        .run()
+        .await?;
+
+        Ok(prefs.clone())
+    }
+
+    /// Return all non-suspended users who have opted into monthly stats emails.
+    ///
+    /// Users with no row in `notification_preferences` are included because a
+    /// missing row means "default = opted in" (LEFT JOIN + COALESCE).
+    pub async fn get_monthly_stats_recipients(
+        &self,
+        db: &D1Database,
+    ) -> Result<Vec<UserForNotification>> {
+        let rows = db
+            .prepare(
+                "SELECT u.id AS user_id, u.email, u.name
+                 FROM users u
+                 LEFT JOIN notification_preferences np ON np.user_id = u.id
+                 WHERE u.suspended_at IS NULL
+                   AND COALESCE(np.email_monthly_stats, 1) = 1",
+            )
+            .all()
+            .await?
+            .results::<serde_json::Value>()?;
+
+        let users = rows
+            .into_iter()
+            .filter_map(|row| {
+                let user_id = row["user_id"].as_str()?.to_string();
+                let email = row["email"].as_str()?.to_string();
+                let name = row["name"].as_str().map(|s| s.to_string());
+                Some(UserForNotification {
+                    user_id,
+                    email,
+                    name,
+                })
+            })
+            .collect();
+
+        Ok(users)
+    }
+}

--- a/src/repositories/notification_preferences_repository.rs
+++ b/src/repositories/notification_preferences_repository.rs
@@ -138,3 +138,90 @@ impl NotificationPreferencesRepository {
         Ok(users)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── NotificationPreferences struct & Default ──────────────────────────────
+
+    #[test]
+    fn test_default_is_fully_opted_in() {
+        // A missing row in the DB is treated as opted in for all notifications.
+        let prefs = NotificationPreferences::default();
+        assert!(
+            prefs.email_monthly_stats,
+            "default should be opted in for monthly stats"
+        );
+    }
+
+    #[test]
+    fn test_explicit_opt_out() {
+        let prefs = NotificationPreferences {
+            email_monthly_stats: false,
+        };
+        assert!(!prefs.email_monthly_stats);
+    }
+
+    #[test]
+    fn test_explicit_opt_in() {
+        let prefs = NotificationPreferences {
+            email_monthly_stats: true,
+        };
+        assert!(prefs.email_monthly_stats);
+    }
+
+    #[test]
+    fn test_clone_preserves_values() {
+        let original = NotificationPreferences {
+            email_monthly_stats: false,
+        };
+        let cloned = original.clone();
+        assert_eq!(cloned.email_monthly_stats, original.email_monthly_stats);
+    }
+
+    // ── UserForNotification struct ────────────────────────────────────────────
+
+    #[test]
+    fn test_user_for_notification_with_name() {
+        let u = UserForNotification {
+            user_id: "u-123".into(),
+            email: "alice@example.com".into(),
+            name: Some("Alice".into()),
+        };
+        assert_eq!(u.user_id, "u-123");
+        assert_eq!(u.email, "alice@example.com");
+        assert_eq!(u.name.as_deref(), Some("Alice"));
+    }
+
+    #[test]
+    fn test_user_for_notification_without_name() {
+        let u = UserForNotification {
+            user_id: "u-456".into(),
+            email: "bob@example.com".into(),
+            name: None,
+        };
+        assert!(u.name.is_none(), "name should be None when not provided");
+    }
+
+    #[test]
+    fn test_user_for_notification_clone_preserves_values() {
+        let u = UserForNotification {
+            user_id: "u-789".into(),
+            email: "charlie@example.com".into(),
+            name: Some("Charlie".into()),
+        };
+        let cloned = u.clone();
+        assert_eq!(cloned.user_id, u.user_id);
+        assert_eq!(cloned.email, u.email);
+        assert_eq!(cloned.name, u.name);
+    }
+
+    // ── Repository construction ───────────────────────────────────────────────
+
+    #[test]
+    fn test_repository_new_does_not_panic() {
+        // Smoke test: constructing the repo must not panic
+        let _repo = NotificationPreferencesRepository::new();
+    }
+}

--- a/src/scheduled/downgrade_expired_subscriptions.rs
+++ b/src/scheduled/downgrade_expired_subscriptions.rs
@@ -43,6 +43,11 @@ pub async fn scheduled(event: ScheduledEvent, env: Env, _ctx: ScheduleContext) {
             };
             super::poll_domain_status::run(&db, &kv, &env).await;
         }
+        "0 8 2 * *" => {
+            console_log!("[cron] Starting monthly stats email job (day 2, 8 AM UTC)");
+            crate::services::email_notification_service::send_monthly_stats_to_all_users(&db, &env)
+                .await;
+        }
         other => {
             console_warn!("[cron] Unexpected cron expression: {}", other);
         }

--- a/src/services/email_notification_service.rs
+++ b/src/services/email_notification_service.rs
@@ -322,4 +322,115 @@ mod tests {
         assert_eq!(month_label(2025, 12), "December 2025");
         assert_eq!(month_label(2026, 1), "January 2026");
     }
+
+    #[test]
+    fn test_month_label_all_twelve_months() {
+        let expected = [
+            (1, "January"),
+            (2, "February"),
+            (3, "March"),
+            (4, "April"),
+            (5, "May"),
+            (6, "June"),
+            (7, "July"),
+            (8, "August"),
+            (9, "September"),
+            (10, "October"),
+            (11, "November"),
+            (12, "December"),
+        ];
+        for (m, name) in expected {
+            assert_eq!(
+                month_label(2026, m),
+                format!("{name} 2026"),
+                "failed for month {m}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_month_label_invalid_month_does_not_panic() {
+        // Month 0 and 13 hit the _ => "Unknown" arm — must not panic
+        assert_eq!(month_label(2026, 0), "Unknown 2026");
+        assert_eq!(month_label(2026, 13), "Unknown 2026");
+    }
+
+    #[test]
+    fn test_previous_month_ranges_february() {
+        // February 2026 → previous month is January 2026, prev-prev is December 2025
+        // This is the case where prev-prev wraps back across a year boundary.
+        let now = Utc.with_ymd_and_hms(2026, 2, 2, 8, 0, 0).unwrap();
+        let (prev_start, prev_end, pp_start, pp_end) = previous_month_ranges(now);
+
+        let jan1_2026 = Utc
+            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        let feb1_2026 = Utc
+            .with_ymd_and_hms(2026, 2, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        let dec1_2025 = Utc
+            .with_ymd_and_hms(2025, 12, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+
+        assert_eq!(prev_start, jan1_2026, "prev month should start Jan 1 2026");
+        assert_eq!(
+            prev_end,
+            feb1_2026 - 1,
+            "prev month should end at end of Jan 2026"
+        );
+        assert_eq!(
+            pp_start, dec1_2025,
+            "prev-prev month should start Dec 1 2025"
+        );
+        assert_eq!(
+            pp_end,
+            jan1_2026 - 1,
+            "prev-prev month should end at end of Dec 2025"
+        );
+    }
+
+    #[test]
+    fn test_previous_month_ranges_march() {
+        // March 2026 → previous is February, prev-prev is January (no year wrap)
+        let now = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
+        let (prev_start, prev_end, pp_start, pp_end) = previous_month_ranges(now);
+
+        let feb1 = Utc
+            .with_ymd_and_hms(2026, 2, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        let mar1 = Utc
+            .with_ymd_and_hms(2026, 3, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        let jan1 = Utc
+            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+
+        assert_eq!(prev_start, feb1);
+        assert_eq!(prev_end, mar1 - 1);
+        assert_eq!(pp_start, jan1);
+        assert_eq!(pp_end, feb1 - 1);
+    }
+
+    #[test]
+    fn test_previous_month_ranges_prev_end_is_one_second_before_current_month() {
+        // Verify the half-open interval: prev_end = first second of current month - 1
+        let now = Utc.with_ymd_and_hms(2026, 6, 3, 8, 0, 0).unwrap();
+        let (_, prev_end, _, _) = previous_month_ranges(now);
+
+        let jun1 = Utc
+            .with_ymd_and_hms(2026, 6, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        assert_eq!(
+            prev_end,
+            jun1 - 1,
+            "prev_end must be exactly 1 second before the current month start"
+        );
+    }
 }

--- a/src/services/email_notification_service.rs
+++ b/src/services/email_notification_service.rs
@@ -1,0 +1,325 @@
+use crate::repositories::notification_preferences_repository::NotificationPreferencesRepository;
+/// Email Notification Service
+///
+/// Sends the monthly statistics summary email to all opted-in users.
+///
+/// Called by the `"0 8 2 * *"` cron trigger (8 AM UTC on day 2 of each month).
+/// Emails are always sent regardless of activity level — zero-link users get a
+/// "create your first link" nudge, zero-click users see their (empty) stats.
+use crate::repositories::{AnalyticsRepository, LinkRepository, OrgRepository};
+use crate::utils::email::{OrgMonthlySummary, TopLinkSummary, send_monthly_stats_email};
+use crate::utils::{get_frontend_url, is_mailgun_configured};
+use chrono::{Datelike, TimeZone, Utc};
+use worker::d1::D1Database;
+use worker::{Env, console_error, console_log, console_warn};
+
+/// Compute the [start, end) Unix timestamps (inclusive) for the previous full
+/// calendar month, and the month before that, relative to `now_utc`.
+///
+/// Returns `(prev_start, prev_end, prev_prev_start, prev_prev_end)`.
+fn previous_month_ranges(now_utc: chrono::DateTime<Utc>) -> (i64, i64, i64, i64) {
+    let this_year = now_utc.year();
+    let this_month = now_utc.month();
+
+    // Previous month
+    let (prev_year, prev_month) = if this_month == 1 {
+        (this_year - 1, 12u32)
+    } else {
+        (this_year, this_month - 1)
+    };
+
+    // Month before that
+    let (prev_prev_year, prev_prev_month) = if prev_month == 1 {
+        (prev_year - 1, 12u32)
+    } else {
+        (prev_year, prev_month - 1)
+    };
+
+    // Build timestamp for first day of a month (midnight UTC)
+    let month_start_ts = |y: i32, m: u32| -> i64 {
+        Utc.with_ymd_and_hms(y, m, 1, 0, 0, 0)
+            .single()
+            .map(|dt| dt.timestamp())
+            .unwrap_or(0)
+    };
+
+    let prev_start = month_start_ts(prev_year, prev_month);
+    let prev_end = month_start_ts(this_year, this_month) - 1;
+    let prev_prev_start = month_start_ts(prev_prev_year, prev_prev_month);
+    let prev_prev_end = prev_start - 1;
+
+    (prev_start, prev_end, prev_prev_start, prev_prev_end)
+}
+
+/// Format a year/month pair as a human-readable label, e.g. "May 2026".
+fn month_label(year: i32, month: u32) -> String {
+    let month_name = match month {
+        1 => "January",
+        2 => "February",
+        3 => "March",
+        4 => "April",
+        5 => "May",
+        6 => "June",
+        7 => "July",
+        8 => "August",
+        9 => "September",
+        10 => "October",
+        11 => "November",
+        12 => "December",
+        _ => "Unknown",
+    };
+    format!("{} {}", month_name, year)
+}
+
+/// Send the monthly statistics email to every opted-in, non-suspended user.
+///
+/// Returns `(sent, errors)` counts.
+pub async fn send_monthly_stats_to_all_users(db: &D1Database, env: &Env) -> (usize, usize) {
+    // Guard: only proceed when Mailgun is configured
+    if !is_mailgun_configured(env) {
+        console_log!("[email_notifications] Mailgun not configured — skipping monthly stats job");
+        return (0, 0);
+    }
+
+    let now = Utc::now();
+    let (prev_year, prev_month) = if now.month() == 1 {
+        (now.year() - 1, 12u32)
+    } else {
+        (now.year(), now.month() - 1)
+    };
+    let label = month_label(prev_year, prev_month);
+    let (prev_start, prev_end, prev_prev_start, prev_prev_end) = previous_month_ranges(now);
+    let frontend_url = get_frontend_url(env);
+
+    let prefs_repo = NotificationPreferencesRepository::new();
+    let org_repo = OrgRepository::new();
+    let link_repo = LinkRepository::new();
+    let analytics_repo = AnalyticsRepository::new();
+
+    // Fetch all opted-in, non-suspended users
+    let recipients = match prefs_repo.get_monthly_stats_recipients(db).await {
+        Ok(r) => r,
+        Err(e) => {
+            console_error!("[email_notifications] Failed to fetch recipients: {}", e);
+            return (0, 1);
+        }
+    };
+
+    console_log!(
+        "[email_notifications] Sending monthly stats ({}) to {} recipient(s)",
+        label,
+        recipients.len()
+    );
+
+    let mut sent = 0usize;
+    let mut errors = 0usize;
+
+    for user in &recipients {
+        // Gather all orgs this user owns
+        let all_orgs = match org_repo.get_user_orgs(db, &user.user_id).await {
+            Ok(orgs) => orgs,
+            Err(e) => {
+                console_warn!(
+                    "[email_notifications] Failed to fetch orgs for user {}: {}",
+                    user.user_id,
+                    e
+                );
+                errors += 1;
+                continue;
+            }
+        };
+
+        // Only include orgs where the user is the owner
+        let owned_orgs: Vec<_> = all_orgs.into_iter().filter(|o| o.role == "owner").collect();
+
+        if owned_orgs.is_empty() {
+            // No owned orgs — nothing meaningful to email about, skip silently
+            continue;
+        }
+
+        // Build per-org summaries
+        let mut org_summaries: Vec<OrgMonthlySummary> = Vec::new();
+
+        for org in &owned_orgs {
+            // Count active links
+            let active_links = match link_repo.get_dashboard_stats(db, &org.id).await {
+                Ok(stats) => stats.active_links,
+                Err(e) => {
+                    console_warn!(
+                        "[email_notifications] Failed to get link stats for org {}: {}",
+                        org.id,
+                        e
+                    );
+                    0
+                }
+            };
+
+            // Total clicks in the previous month
+            let total_clicks = match analytics_repo
+                .get_org_total_clicks_in_range(db, &org.id, prev_start, prev_end)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    console_warn!(
+                        "[email_notifications] Failed to get clicks for org {}: {}",
+                        org.id,
+                        e
+                    );
+                    0
+                }
+            };
+
+            // Comparison: clicks in the month before the previous one
+            let prev_month_clicks = match analytics_repo
+                .get_org_total_clicks_in_range(db, &org.id, prev_prev_start, prev_prev_end)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    console_warn!(
+                        "[email_notifications] Failed to get prev-prev clicks for org {}: {}",
+                        org.id,
+                        e
+                    );
+                    0
+                }
+            };
+
+            // Top links — only fetched when there were clicks
+            let top_links = if total_clicks > 0 {
+                match analytics_repo
+                    .get_org_top_links(db, &org.id, prev_start, prev_end, 5)
+                    .await
+                {
+                    Ok(links) => links
+                        .into_iter()
+                        .map(|l| TopLinkSummary {
+                            short_code: l.short_code,
+                            title: l.title,
+                            clicks: l.count,
+                        })
+                        .collect(),
+                    Err(e) => {
+                        console_warn!(
+                            "[email_notifications] Failed to get top links for org {}: {}",
+                            org.id,
+                            e
+                        );
+                        vec![]
+                    }
+                }
+            } else {
+                vec![]
+            };
+
+            org_summaries.push(OrgMonthlySummary {
+                org_name: org.name.clone(),
+                total_links: active_links,
+                total_clicks,
+                prev_month_clicks,
+                top_links,
+            });
+        }
+
+        // Send the email — always, even if all orgs have zero activity
+        match send_monthly_stats_email(
+            env,
+            &user.email,
+            user.name.as_deref(),
+            &label,
+            &org_summaries,
+            &frontend_url,
+        )
+        .await
+        {
+            Ok(()) => {
+                console_log!(
+                    "[email_notifications] Sent monthly stats to {} ({})",
+                    user.email,
+                    user.user_id
+                );
+                sent += 1;
+            }
+            Err(e) => {
+                console_error!(
+                    "[email_notifications] Failed to send to {} ({}): {}",
+                    user.email,
+                    user.user_id,
+                    e
+                );
+                errors += 1;
+            }
+        }
+    }
+
+    console_log!(
+        "[email_notifications] Monthly stats job complete: {} sent, {} error(s)",
+        sent,
+        errors
+    );
+    (sent, errors)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_previous_month_ranges_mid_year() {
+        // June 3rd 2026 → previous month is May 2026, prev-prev is April 2026
+        let now = Utc.with_ymd_and_hms(2026, 6, 3, 8, 0, 0).unwrap();
+        let (prev_start, prev_end, pp_start, pp_end) = previous_month_ranges(now);
+
+        let may1 = Utc
+            .with_ymd_and_hms(2026, 5, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        let jun1 = Utc
+            .with_ymd_and_hms(2026, 6, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        let apr1 = Utc
+            .with_ymd_and_hms(2026, 4, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+
+        assert_eq!(prev_start, may1);
+        assert_eq!(prev_end, jun1 - 1);
+        assert_eq!(pp_start, apr1);
+        assert_eq!(pp_end, may1 - 1);
+    }
+
+    #[test]
+    fn test_previous_month_ranges_january() {
+        // January 2nd 2026 → previous month is December 2025, prev-prev is November 2025
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 8, 0, 0).unwrap();
+        let (prev_start, prev_end, pp_start, pp_end) = previous_month_ranges(now);
+
+        let dec1_2025 = Utc
+            .with_ymd_and_hms(2025, 12, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        let jan1_2026 = Utc
+            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        let nov1_2025 = Utc
+            .with_ymd_and_hms(2025, 11, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+
+        assert_eq!(prev_start, dec1_2025);
+        assert_eq!(prev_end, jan1_2026 - 1);
+        assert_eq!(pp_start, nov1_2025);
+        assert_eq!(pp_end, dec1_2025 - 1);
+    }
+
+    #[test]
+    fn test_month_label() {
+        assert_eq!(month_label(2026, 5), "May 2026");
+        assert_eq!(month_label(2025, 12), "December 2025");
+        assert_eq!(month_label(2026, 1), "January 2026");
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -20,6 +20,7 @@ pub mod auth_service;
 pub mod billing_service;
 pub mod blacklist_service;
 pub mod domain_service;
+pub mod email_notification_service;
 pub mod link_service;
 pub mod oauth_service;
 pub mod org_service;

--- a/src/services/settings_service.rs
+++ b/src/services/settings_service.rs
@@ -95,7 +95,11 @@ impl SettingsService {
     }
 
     /// Get public settings for frontend consumption
-    pub async fn get_public_settings(&self, db: &D1Database) -> Result<serde_json::Value> {
+    pub async fn get_public_settings(
+        &self,
+        db: &D1Database,
+        env: &worker::Env,
+    ) -> Result<serde_json::Value> {
         let settings = self.repository.get_all_settings(db).await?;
 
         // Get founder pricing status from settings
@@ -112,12 +116,16 @@ impl SettingsService {
                 .unwrap_or(0)
         };
 
+        // Email notification toggles are only shown when Mailgun is configured
+        let email_notifications_enabled = crate::utils::is_mailgun_configured(env);
+
         Ok(serde_json::json!({
             "founder_pricing_active": founder_pricing_active,
             "active_discount_amount_pro_monthly": get_setting_i64("active_discount_amount_pro_monthly"),
             "active_discount_amount_pro_annual": get_setting_i64("active_discount_amount_pro_annual"),
             "active_discount_amount_business_monthly": get_setting_i64("active_discount_amount_business_monthly"),
             "active_discount_amount_business_annual": get_setting_i64("active_discount_amount_business_annual"),
+            "email_notifications_enabled": email_notifications_enabled,
         }))
     }
 }

--- a/src/utils/email.rs
+++ b/src/utils/email.rs
@@ -1,5 +1,31 @@
 use worker::{Env, Fetch, Method, Request, RequestInit, Result};
 
+// ── Monthly stats email data structures ─────────────────────────────────────
+
+/// A single link's performance summary for the monthly stats email.
+#[derive(Debug, Clone)]
+pub struct TopLinkSummary {
+    pub short_code: String,
+    pub title: Option<String>,
+    pub clicks: i64,
+}
+
+/// Per-org analytics summary included in the monthly stats email.
+#[derive(Debug, Clone)]
+pub struct OrgMonthlySummary {
+    /// Display name of the organization.
+    pub org_name: String,
+    /// Total active links in this org (used to distinguish "no links" vs "zero clicks").
+    pub total_links: i64,
+    /// Total clicks on this org's links in the previous calendar month.
+    pub total_clicks: i64,
+    /// Total clicks in the month before the previous one (for % comparison).
+    /// Zero means no comparison data available.
+    pub prev_month_clicks: i64,
+    /// Top links by click count (up to 5). Empty when total_clicks == 0.
+    pub top_links: Vec<TopLinkSummary>,
+}
+
 /// Send an organization invitation email via Mailgun
 pub async fn send_org_invitation(
     env: &Env,
@@ -71,19 +97,373 @@ pub async fn send_org_invitation(
         inviter_name, org_name, invite_url
     );
 
-    // Build multipart/form-data body manually (Cloudflare Workers doesn't support FormData in fetch)
+    send_via_mailgun(
+        env, &api_key, &base_url, &domain, &from, to_email, &subject, &html_body, &text_body,
+    )
+    .await
+}
+
+/// Send the monthly statistics summary email to a single user via Mailgun.
+///
+/// The email is always sent regardless of activity level:
+/// - If an org has no links yet, a "create your first link" nudge is shown.
+/// - If an org has links but zero clicks, stats are shown with an encouragement note.
+/// - If an org has clicks, full stats and top-links table are shown.
+///
+/// `month_label` should be a human-readable string like "May 2026".
+#[allow(clippy::too_many_arguments)]
+pub async fn send_monthly_stats_email(
+    env: &Env,
+    to_email: &str,
+    user_name: Option<&str>,
+    month_label: &str,
+    orgs_data: &[OrgMonthlySummary],
+    frontend_url: &str,
+) -> Result<()> {
+    let api_key = env
+        .var("MAILGUN_API_KEY")
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let base_url = env
+        .var("MAILGUN_BASE_URL")
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let domain = env
+        .var("MAILGUN_DOMAIN")
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let from = env
+        .var("MAILGUN_FROM")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| format!("noreply@{domain}"));
+
+    if api_key.is_empty() || domain.is_empty() {
+        return Err(worker::Error::RustError(
+            "Mailgun not configured: MAILGUN_API_KEY and MAILGUN_DOMAIN are required".to_string(),
+        ));
+    }
+
+    let greeting = user_name.unwrap_or("there");
+    let subject = format!("Your {month_label} Rushomon recap");
+
+    // ── Build per-org HTML sections ──────────────────────────────────────────
+    let mut org_sections_html = String::new();
+    let mut org_sections_text = String::new();
+
+    for org in orgs_data {
+        if org.total_links == 0 {
+            // Org has no links at all — nudge user to create one
+            org_sections_html.push_str(&format!(
+                r#"
+  <div style="border:1px solid #e5e7eb; border-radius:12px; padding:24px; margin-bottom:20px;">
+    <h3 style="margin:0 0 8px 0; color:#111827; font-size:15px; font-weight:600;">{org_name}</h3>
+    <p style="margin:0 0 20px 0; color:#6b7280; font-size:14px; line-height:1.5;">
+      You haven't created any short links in this organization yet.
+    </p>
+    <a href="{frontend_url}/dashboard"
+       style="background:#f97316; color:#ffffff; padding:10px 20px;
+              text-decoration:none; border-radius:8px; font-weight:600;
+              display:inline-block; font-size:14px;">
+      Create your first link →
+    </a>
+  </div>"#,
+                org_name = escape_html(&org.org_name),
+                frontend_url = frontend_url,
+            ));
+            org_sections_text.push_str(&format!(
+                "\n--- {} ---\nYou haven't created any short links yet. Get started: {}/dashboard\n",
+                org.org_name, frontend_url,
+            ));
+        } else if org.total_clicks == 0 {
+            // Has links but zero clicks
+            let links_word = if org.total_links == 1 {
+                "link"
+            } else {
+                "links"
+            };
+            org_sections_html.push_str(&format!(
+                r#"
+  <div style="border:1px solid #e5e7eb; border-radius:12px; padding:24px; margin-bottom:20px;">
+    <h3 style="margin:0 0 2px 0; color:#111827; font-size:15px; font-weight:600;">{org_name}</h3>
+    <p style="margin:0 0 16px 0; color:#9ca3af; font-size:13px;">{total_links} active {links_word}</p>
+    <div style="border:1px solid #e5e7eb; border-radius:8px; padding:16px 20px; margin-bottom:16px;">
+      <p style="margin:0; font-size:28px; font-weight:700; color:#111827; line-height:1.2;">0 clicks</p>
+      <p style="margin:6px 0 0 0; color:#9ca3af; font-size:13px;">in {month_label}</p>
+    </div>
+    <p style="color:#6b7280; font-size:14px; margin:0 0 16px 0; line-height:1.5;">
+      No clicks recorded last month — share your links to start seeing traffic!
+    </p>
+    <a href="{frontend_url}/dashboard/analytics"
+       style="color:#f97316; font-size:14px; text-decoration:none; font-weight:500;">
+      View analytics →
+    </a>
+  </div>"#,
+                org_name = escape_html(&org.org_name),
+                total_links = org.total_links,
+                links_word = links_word,
+                month_label = month_label,
+                frontend_url = frontend_url,
+            ));
+            org_sections_text.push_str(&format!(
+                "\n--- {} ---\n0 clicks in {} ({} active {}).\nShare your links to start seeing traffic!\nView analytics: {}/dashboard/analytics\n",
+                org.org_name, month_label, org.total_links, links_word, frontend_url,
+            ));
+        } else {
+            // Normal stats with clicks
+            let trend_html = build_trend_html(org.total_clicks, org.prev_month_clicks);
+            let trend_text = build_trend_text(org.total_clicks, org.prev_month_clicks);
+            let top_links_html = build_top_links_html(&org.top_links);
+            let top_links_text = build_top_links_text(&org.top_links);
+            let links_word = if org.total_links == 1 {
+                "link"
+            } else {
+                "links"
+            };
+
+            org_sections_html.push_str(&format!(
+                r#"
+  <div style="border:1px solid #e5e7eb; border-radius:12px; padding:24px; margin-bottom:20px;">
+    <h3 style="margin:0 0 2px 0; color:#111827; font-size:15px; font-weight:600;">{org_name}</h3>
+    <p style="margin:0 0 16px 0; color:#9ca3af; font-size:13px;">{total_links} active {links_word}</p>
+    <div style="border:1px solid #e5e7eb; border-radius:8px; padding:16px 20px; margin-bottom:16px;">
+      <table cellpadding="0" cellspacing="0" border="0">
+        <tr>
+          <td style="vertical-align:baseline; padding-right:12px;">
+            <p style="margin:0; font-size:28px; font-weight:700; color:#111827; line-height:1.2;">{total_clicks} clicks</p>
+            <p style="margin:6px 0 0 0; color:#9ca3af; font-size:13px;">in {month_label}</p>
+          </td>
+          <td style="vertical-align:middle;">{trend_html}</td>
+        </tr>
+      </table>
+    </div>
+    {top_links_html}
+    <a href="{frontend_url}/dashboard/analytics"
+       style="color:#f97316; font-size:14px; text-decoration:none; font-weight:500; display:inline-block; margin-top:12px;">
+      View full analytics →
+    </a>
+  </div>"#,
+                org_name = escape_html(&org.org_name),
+                total_links = org.total_links,
+                links_word = links_word,
+                total_clicks = org.total_clicks,
+                month_label = month_label,
+                trend_html = trend_html,
+                top_links_html = top_links_html,
+                frontend_url = frontend_url,
+            ));
+            org_sections_text.push_str(&format!(
+                "\n--- {} ---\n{} clicks in {} ({} active {}).{}\n{}\nView analytics: {}/dashboard/analytics\n",
+                org.org_name,
+                org.total_clicks,
+                month_label,
+                org.total_links,
+                links_word,
+                trend_text,
+                top_links_text,
+                frontend_url,
+            ));
+        }
+    }
+
+    // ── Assemble full email ──────────────────────────────────────────────────
+    let settings_url = format!("{frontend_url}/settings");
+
+    let html_body = format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Your {month_label} Rushomon recap</title>
+</head>
+<body style="margin:0; padding:0; background:#ffffff; font-family:-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,sans-serif; color:#111827;">
+  <div style="max-width:600px; margin:0 auto; padding:40px 24px 48px;">
+
+    <!-- Logo -->
+    <div style="margin-bottom:32px;">
+      <table cellpadding="0" cellspacing="0" border="0">
+        <tr>
+          <td style="vertical-align:middle;">
+            <div style="width:32px; height:32px;
+                        background:linear-gradient(135deg, #f97316 0%, #ea580c 100%);
+                        border-radius:8px; text-align:center; line-height:32px;
+                        font-size:14px; font-weight:700; color:#ffffff;">R</div>
+          </td>
+          <td style="vertical-align:middle; padding-left:8px;">
+            <span style="font-size:24px; font-weight:700; color:#111827; line-height:1;">Rushomon</span>
+          </td>
+        </tr>
+      </table>
+    </div>
+
+    <!-- Heading -->
+    <h1 style="font-size:24px; font-weight:700; color:#111827; margin:0 0 6px 0; line-height:1.3;">
+      Your {month_label} recap, {greeting}!
+    </h1>
+    <p style="color:#6b7280; font-size:15px; margin:0 0 32px 0; line-height:1.5;">
+      Here's how your short links performed last month.
+    </p>
+
+    {org_sections}
+
+    <!-- Footer -->
+    <div style="border-top:1px solid #e5e7eb; margin-top:40px; padding-top:24px;">
+      <p style="color:#9ca3af; font-size:12px; margin:0; line-height:1.6;">
+        You're receiving this because you have monthly stats emails enabled on
+        <a href="{frontend_url}" style="color:#f97316; text-decoration:none;">Rushomon</a>.
+        To stop receiving these emails, visit your
+        <a href="{settings_url}" style="color:#f97316; text-decoration:none;">account settings</a>.
+      </p>
+    </div>
+
+  </div>
+</body>
+</html>"#,
+        month_label = month_label,
+        greeting = escape_html(greeting),
+        org_sections = org_sections_html,
+        frontend_url = frontend_url,
+        settings_url = settings_url,
+    );
+
+    let text_body = format!(
+        "Your {month_label} Rushomon recap, {greeting}!\n\nHere's how your short links performed last month.\n{org_sections}\n\n---\nTo stop receiving these emails, visit {settings_url}",
+        month_label = month_label,
+        greeting = greeting,
+        org_sections = org_sections_text,
+        settings_url = settings_url,
+    );
+
+    send_via_mailgun(
+        env, &api_key, &base_url, &domain, &from, to_email, &subject, &html_body, &text_body,
+    )
+    .await
+}
+
+// ── Private helpers ──────────────────────────────────────────────────────────
+
+/// Escape the minimum set of HTML special characters.
+fn escape_html(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Build the trend badge HTML (e.g. "↑12%" in green, "↓5%" in red, "New" in blue).
+fn build_trend_html(current: i64, previous: i64) -> String {
+    if previous == 0 {
+        return r#"<span style="background:#fff7ed; color:#f97316; font-size:12px; font-weight:600;
+                               padding:3px 9px; border-radius:9999px; white-space:nowrap;">New</span>"#.to_string();
+    }
+    let pct = ((current - previous) as f64 / previous as f64 * 100.0).round() as i64;
+    if pct >= 0 {
+        format!(
+            r#"<span style="background:#dcfce7; color:#15803d; font-size:12px; font-weight:600;
+                            padding:3px 9px; border-radius:9999px; white-space:nowrap;">↑{pct}%</span>"#
+        )
+    } else {
+        format!(
+            r#"<span style="background:#fee2e2; color:#b91c1c; font-size:12px; font-weight:600;
+                            padding:3px 9px; border-radius:9999px; white-space:nowrap;">↓{}%</span>"#,
+            pct.unsigned_abs()
+        )
+    }
+}
+
+/// Build a plain-text trend string.
+fn build_trend_text(current: i64, previous: i64) -> String {
+    if previous == 0 {
+        return " (New)".to_string();
+    }
+    let pct = ((current - previous) as f64 / previous as f64 * 100.0).round() as i64;
+    if pct >= 0 {
+        format!(" (↑{pct}% vs last month)")
+    } else {
+        format!(" (↓{}% vs last month)", pct.unsigned_abs())
+    }
+}
+
+/// Build the top-links table HTML.
+fn build_top_links_html(links: &[TopLinkSummary]) -> String {
+    if links.is_empty() {
+        return String::new();
+    }
+    let mut rows = String::new();
+    for link in links {
+        let label = link
+            .title
+            .as_deref()
+            .filter(|t| !t.is_empty())
+            .unwrap_or(&link.short_code);
+        rows.push_str(&format!(
+            r#"<tr>
+          <td style="padding:8px 0; color:#374151; font-size:13px; border-bottom:1px solid #f3f4f6;">{label}</td>
+          <td style="padding:8px 0; color:#6b7280; font-size:13px; border-bottom:1px solid #f3f4f6; text-align:right; white-space:nowrap;">/{short_code}</td>
+          <td style="padding:8px 0; font-size:13px; font-weight:600; color:#111827; border-bottom:1px solid #f3f4f6; text-align:right; padding-left:16px;">{clicks}</td>
+        </tr>"#,
+            label = escape_html(label),
+            short_code = escape_html(&link.short_code),
+            clicks = link.clicks,
+        ));
+    }
+    format!(
+        r#"<table style="width:100%; border-collapse:collapse; margin-bottom:8px;">
+      <thead>
+        <tr>
+          <th style="text-align:left; color:#9ca3af; font-size:11px; font-weight:600; padding-bottom:6px; text-transform:uppercase; letter-spacing:.05em;">Link</th>
+          <th style="text-align:right; color:#9ca3af; font-size:11px; font-weight:600; padding-bottom:6px; text-transform:uppercase; letter-spacing:.05em;"></th>
+          <th style="text-align:right; color:#9ca3af; font-size:11px; font-weight:600; padding-bottom:6px; text-transform:uppercase; letter-spacing:.05em; padding-left:16px;">Clicks</th>
+        </tr>
+      </thead>
+      <tbody>{rows}</tbody>
+    </table>"#
+    )
+}
+
+/// Build the top-links plain-text block.
+fn build_top_links_text(links: &[TopLinkSummary]) -> String {
+    if links.is_empty() {
+        return String::new();
+    }
+    let mut out = "\nTop links:\n".to_string();
+    for link in links {
+        let label = link
+            .title
+            .as_deref()
+            .filter(|t| !t.is_empty())
+            .unwrap_or(&link.short_code);
+        out.push_str(&format!(
+            "  {} (/{}) — {} clicks\n",
+            label, link.short_code, link.clicks
+        ));
+    }
+    out
+}
+
+/// Send a message via the Mailgun REST API.
+#[allow(clippy::too_many_arguments)]
+async fn send_via_mailgun(
+    _env: &Env,
+    api_key: &str,
+    base_url: &str,
+    domain: &str,
+    from: &str,
+    to: &str,
+    subject: &str,
+    html: &str,
+    text: &str,
+) -> Result<()> {
     let form_body = format!(
         "from={}&to={}&subject={}&html={}&text={}",
-        urlencoding::encode(&from),
-        urlencoding::encode(to_email),
-        urlencoding::encode(&subject),
-        urlencoding::encode(&html_body),
-        urlencoding::encode(&text_body),
+        urlencoding::encode(from),
+        urlencoding::encode(to),
+        urlencoding::encode(subject),
+        urlencoding::encode(html),
+        urlencoding::encode(text),
     );
 
     let mailgun_url = format!("{}/v3/{}/messages", base_url, domain);
-
-    // Basic auth: "api:{api_key}" base64-encoded
     let credentials = format!("api:{}", api_key);
     let auth_header = format!("Basic {}", base64_encode(credentials.as_bytes()));
 

--- a/src/utils/email.rs
+++ b/src/utils/email.rs
@@ -528,3 +528,320 @@ mod urlencoding {
         url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── escape_html ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_escape_html_ampersand() {
+        assert_eq!(escape_html("a&b"), "a&amp;b");
+    }
+
+    #[test]
+    fn test_escape_html_lt_gt() {
+        assert_eq!(escape_html("<b>"), "&lt;b&gt;");
+    }
+
+    #[test]
+    fn test_escape_html_double_quote() {
+        assert_eq!(escape_html(r#"say "hi""#), "say &quot;hi&quot;");
+    }
+
+    #[test]
+    fn test_escape_html_combined() {
+        assert_eq!(
+            escape_html(r#"<a href="x&y">"#),
+            "&lt;a href=&quot;x&amp;y&quot;&gt;"
+        );
+    }
+
+    #[test]
+    fn test_escape_html_clean_passthrough() {
+        assert_eq!(escape_html("hello world"), "hello world");
+    }
+
+    #[test]
+    fn test_escape_html_empty_string() {
+        assert_eq!(escape_html(""), "");
+    }
+
+    #[test]
+    fn test_escape_html_multiple_ampersands() {
+        assert_eq!(escape_html("a&b&c"), "a&amp;b&amp;c");
+    }
+
+    // ── build_trend_html ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_trend_html_new_when_previous_zero() {
+        let html = build_trend_html(100, 0);
+        assert!(html.contains("New"), "expected 'New' badge, got: {html}");
+    }
+
+    #[test]
+    fn test_trend_html_new_when_both_zero() {
+        // previous == 0 always triggers "New", regardless of current
+        let html = build_trend_html(0, 0);
+        assert!(html.contains("New"), "expected 'New' badge, got: {html}");
+    }
+
+    #[test]
+    fn test_trend_html_positive_ten_percent() {
+        let html = build_trend_html(110, 100);
+        assert!(html.contains("↑10%"), "expected '↑10%', got: {html}");
+    }
+
+    #[test]
+    fn test_trend_html_negative_ten_percent() {
+        let html = build_trend_html(90, 100);
+        assert!(html.contains("↓10%"), "expected '↓10%', got: {html}");
+    }
+
+    #[test]
+    fn test_trend_html_zero_change_shows_up_zero() {
+        let html = build_trend_html(100, 100);
+        assert!(html.contains("↑0%"), "expected '↑0%', got: {html}");
+    }
+
+    #[test]
+    fn test_trend_html_large_positive() {
+        let html = build_trend_html(300, 100);
+        assert!(html.contains("↑200%"), "expected '↑200%', got: {html}");
+    }
+
+    #[test]
+    fn test_trend_html_large_negative() {
+        let html = build_trend_html(1, 100);
+        assert!(html.contains("↓99%"), "expected '↓99%', got: {html}");
+    }
+
+    #[test]
+    fn test_trend_html_rounding() {
+        // 1/3 ≈ 33.33% rounds to 33%
+        let html = build_trend_html(133, 100);
+        assert!(html.contains("↑33%"), "expected '↑33%', got: {html}");
+    }
+
+    // ── build_trend_text ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_trend_text_new_when_previous_zero() {
+        assert_eq!(build_trend_text(5, 0), " (New)");
+    }
+
+    #[test]
+    fn test_trend_text_positive() {
+        let text = build_trend_text(200, 100);
+        assert!(text.contains("↑100%"), "expected '↑100%', got: {text}");
+        assert!(text.contains("vs last month"));
+    }
+
+    #[test]
+    fn test_trend_text_negative() {
+        let text = build_trend_text(50, 100);
+        assert!(text.contains("↓50%"), "expected '↓50%', got: {text}");
+        assert!(text.contains("vs last month"));
+    }
+
+    #[test]
+    fn test_trend_text_zero_change() {
+        let text = build_trend_text(100, 100);
+        assert!(text.contains("↑0%"), "expected '↑0%', got: {text}");
+    }
+
+    // ── build_top_links_html ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_top_links_html_empty_returns_empty_string() {
+        assert_eq!(build_top_links_html(&[]), String::new());
+    }
+
+    #[test]
+    fn test_top_links_html_uses_title_when_present() {
+        let link = TopLinkSummary {
+            short_code: "abc".into(),
+            title: Some("My Link".into()),
+            clicks: 42,
+        };
+        let html = build_top_links_html(&[link]);
+        assert!(html.contains("My Link"), "title should appear in HTML");
+        assert!(html.contains("/abc"), "short_code should appear as /abc");
+        assert!(html.contains("42"), "click count should appear");
+    }
+
+    #[test]
+    fn test_top_links_html_falls_back_to_short_code_when_no_title() {
+        let link = TopLinkSummary {
+            short_code: "xyz".into(),
+            title: None,
+            clicks: 5,
+        };
+        let html = build_top_links_html(&[link]);
+        // short_code used as the label in the first <td>
+        let count = html.matches("xyz").count();
+        assert!(
+            count >= 2,
+            "short_code should appear as both label and code column, got {count} occurrences in: {html}"
+        );
+    }
+
+    #[test]
+    fn test_top_links_html_falls_back_to_short_code_when_title_empty() {
+        let link = TopLinkSummary {
+            short_code: "xyz".into(),
+            title: Some("".into()), // empty string → fall back to short_code
+            clicks: 5,
+        };
+        let html = build_top_links_html(&[link]);
+        let count = html.matches("xyz").count();
+        assert!(
+            count >= 2,
+            "empty title should fall back to short_code as label, got {count} occurrences"
+        );
+    }
+
+    #[test]
+    fn test_top_links_html_escapes_special_chars_in_title() {
+        let link = TopLinkSummary {
+            short_code: "ok".into(),
+            title: Some("<script>alert(1)</script>".into()),
+            clicks: 1,
+        };
+        let html = build_top_links_html(&[link]);
+        assert!(
+            !html.contains("<script>"),
+            "raw <script> tag must not appear in HTML"
+        );
+        assert!(
+            html.contains("&lt;script&gt;"),
+            "title must be HTML-escaped"
+        );
+    }
+
+    #[test]
+    fn test_top_links_html_escapes_special_chars_in_short_code() {
+        let link = TopLinkSummary {
+            short_code: "a&b".into(),
+            title: None,
+            clicks: 3,
+        };
+        let html = build_top_links_html(&[link]);
+        assert!(
+            !html.contains("a&b"),
+            "raw & in short_code must not appear unescaped"
+        );
+        assert!(html.contains("a&amp;b"), "short_code must be HTML-escaped");
+    }
+
+    #[test]
+    fn test_top_links_html_multiple_links() {
+        let links = vec![
+            TopLinkSummary {
+                short_code: "a1".into(),
+                title: Some("Alpha".into()),
+                clicks: 100,
+            },
+            TopLinkSummary {
+                short_code: "b2".into(),
+                title: Some("Beta".into()),
+                clicks: 50,
+            },
+            TopLinkSummary {
+                short_code: "c3".into(),
+                title: None,
+                clicks: 10,
+            },
+        ];
+        let html = build_top_links_html(&links);
+        assert!(html.contains("Alpha"));
+        assert!(html.contains("Beta"));
+        assert!(html.contains("c3"));
+        assert!(html.contains("100"));
+        assert!(html.contains("50"));
+        assert!(html.contains("10"));
+    }
+
+    // ── build_top_links_text ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_top_links_text_empty_returns_empty_string() {
+        assert_eq!(build_top_links_text(&[]), String::new());
+    }
+
+    #[test]
+    fn test_top_links_text_uses_title_when_present() {
+        let link = TopLinkSummary {
+            short_code: "abc".into(),
+            title: Some("My Link".into()),
+            clicks: 7,
+        };
+        let text = build_top_links_text(&[link]);
+        assert!(text.contains("My Link"), "title should appear in text");
+        assert!(text.contains("/abc"), "short_code should appear with /");
+        assert!(text.contains("7 clicks"), "click count should appear");
+    }
+
+    #[test]
+    fn test_top_links_text_falls_back_to_short_code_when_no_title() {
+        let link = TopLinkSummary {
+            short_code: "xyz".into(),
+            title: None,
+            clicks: 3,
+        };
+        let text = build_top_links_text(&[link]);
+        assert!(text.contains("xyz"), "short_code should be the label");
+    }
+
+    #[test]
+    fn test_top_links_text_falls_back_to_short_code_when_title_empty() {
+        let link = TopLinkSummary {
+            short_code: "xyz".into(),
+            title: Some("".into()),
+            clicks: 3,
+        };
+        let text = build_top_links_text(&[link]);
+        // label should be short_code, not empty string
+        assert!(
+            text.contains("xyz"),
+            "empty title should fall back to short_code"
+        );
+    }
+
+    #[test]
+    fn test_top_links_text_header_line() {
+        let link = TopLinkSummary {
+            short_code: "x".into(),
+            title: None,
+            clicks: 1,
+        };
+        let text = build_top_links_text(&[link]);
+        assert!(
+            text.starts_with("\nTop links:\n"),
+            "text block should start with header, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn test_top_links_text_multiple_links() {
+        let links = vec![
+            TopLinkSummary {
+                short_code: "a1".into(),
+                title: Some("Alpha".into()),
+                clicks: 10,
+            },
+            TopLinkSummary {
+                short_code: "b2".into(),
+                title: None,
+                clicks: 5,
+            },
+        ];
+        let text = build_top_links_text(&links);
+        assert!(text.contains("Alpha"));
+        assert!(text.contains("b2"));
+        assert!(text.contains("10 clicks"));
+        assert!(text.contains("5 clicks"));
+    }
+}

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -32,3 +32,20 @@ pub fn get_scheme(env: &Env) -> String {
         "https".to_string()
     }
 }
+
+/// Returns true when the minimum Mailgun environment variables are present.
+///
+/// Used to conditionally enable email features (sending emails, surfacing
+/// notification preference toggles in the UI, etc.).
+/// Requires both `MAILGUN_API_KEY` and `MAILGUN_DOMAIN` to be non-empty.
+pub fn is_mailgun_configured(env: &Env) -> bool {
+    let api_key = env
+        .var("MAILGUN_API_KEY")
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let domain = env
+        .var("MAILGUN_DOMAIN")
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    !api_key.is_empty() && !domain.is_empty()
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,7 +14,7 @@ pub mod url_normalization;
 pub mod validation;
 
 pub use crypto::{secure_compare, verify_polar_webhook_signature};
-pub use env::{get_fallback_domain, get_frontend_url};
+pub use env::{get_fallback_domain, get_frontend_url, is_mailgun_configured};
 pub use errors::AppError;
 pub use http::{get_client_ip, hash_ip};
 pub use query_params::QueryParams;

--- a/tests/notifications_test.rs
+++ b/tests/notifications_test.rs
@@ -1,0 +1,339 @@
+use reqwest::StatusCode;
+use serde_json::json;
+
+mod common;
+use common::*;
+
+// ── GET /api/notifications/preferences ───────────────────────────────────────
+
+#[tokio::test]
+async fn test_get_preferences_requires_auth() {
+    let client = test_client();
+
+    let response = client
+        .get(format!("{}/api/notifications/preferences", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_get_preferences_returns_defaults_when_no_row_exists() {
+    // A fresh authenticated user who has never touched their preferences
+    // should get all flags as true (the "opt-in by default" invariant).
+    let client = authenticated_client();
+
+    let response = client
+        .get(format!("{}/api/notifications/preferences", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    assert!(
+        body["email_monthly_stats"].is_boolean(),
+        "email_monthly_stats must be a boolean, got: {:?}",
+        body
+    );
+    // Default: opted in (true). The user has not yet called PATCH so no row
+    // exists; the repository must return the default value.
+    assert_eq!(
+        body["email_monthly_stats"].as_bool().unwrap(),
+        true,
+        "fresh user should default to opted-in"
+    );
+}
+
+#[tokio::test]
+async fn test_get_preferences_response_shape() {
+    let client = authenticated_client();
+
+    let response = client
+        .get(format!("{}/api/notifications/preferences", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    // The response must be an object (not an array, not null, not a scalar).
+    assert!(
+        body.is_object(),
+        "preferences response must be a JSON object, got: {:?}",
+        body
+    );
+
+    // email_monthly_stats must always be present.
+    assert!(
+        body.get("email_monthly_stats").is_some(),
+        "email_monthly_stats key must be present in response"
+    );
+}
+
+// ── PATCH /api/notifications/preferences ─────────────────────────────────────
+
+#[tokio::test]
+async fn test_patch_preferences_requires_auth() {
+    let client = test_client();
+
+    let response = client
+        .patch(format!("{}/api/notifications/preferences", BASE_URL))
+        .json(&json!({ "email_monthly_stats": false }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_patch_preferences_invalid_json_returns_400() {
+    let client = authenticated_client();
+
+    let response = client
+        .patch(format!("{}/api/notifications/preferences", BASE_URL))
+        .header("Content-Type", "application/json")
+        .body("this is not json")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_patch_preferences_opt_out_and_back_in() {
+    let client = authenticated_client();
+
+    // Step 1 — opt out
+    let opt_out = client
+        .patch(format!("{}/api/notifications/preferences", BASE_URL))
+        .json(&json!({ "email_monthly_stats": false }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        opt_out.status(),
+        StatusCode::OK,
+        "PATCH opt-out should return 200"
+    );
+
+    let after_opt_out: serde_json::Value = opt_out.json().await.unwrap();
+    assert_eq!(
+        after_opt_out["email_monthly_stats"].as_bool().unwrap(),
+        false,
+        "email_monthly_stats should be false after opt-out"
+    );
+
+    // Step 2 — verify GET reflects the persisted value
+    let get_response = client
+        .get(format!("{}/api/notifications/preferences", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let get_body: serde_json::Value = get_response.json().await.unwrap();
+    assert_eq!(
+        get_body["email_monthly_stats"].as_bool().unwrap(),
+        false,
+        "GET after opt-out should still return false"
+    );
+
+    // Step 3 — opt back in (restore state for other tests)
+    let opt_in = client
+        .patch(format!("{}/api/notifications/preferences", BASE_URL))
+        .json(&json!({ "email_monthly_stats": true }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        opt_in.status(),
+        StatusCode::OK,
+        "PATCH opt-in should return 200"
+    );
+
+    let after_opt_in: serde_json::Value = opt_in.json().await.unwrap();
+    assert_eq!(
+        after_opt_in["email_monthly_stats"].as_bool().unwrap(),
+        true,
+        "email_monthly_stats should be true after opt-in"
+    );
+}
+
+#[tokio::test]
+async fn test_patch_preferences_returns_updated_preferences() {
+    let client = authenticated_client();
+
+    // PATCH must return the full, updated preferences object (not just the
+    // field that was patched).
+    let response = client
+        .patch(format!("{}/api/notifications/preferences", BASE_URL))
+        .json(&json!({ "email_monthly_stats": false }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    assert!(
+        body.is_object(),
+        "PATCH response must be a JSON object, got: {:?}",
+        body
+    );
+    assert!(
+        body.get("email_monthly_stats").is_some(),
+        "PATCH response must include email_monthly_stats"
+    );
+
+    // Restore state
+    client
+        .patch(format!("{}/api/notifications/preferences", BASE_URL))
+        .json(&json!({ "email_monthly_stats": true }))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_patch_preferences_empty_body_preserves_existing_value() {
+    // An empty JSON object `{}` is a valid PATCH — it should be a no-op
+    // (all fields default to None in the request struct, so existing values
+    // are kept unchanged).
+    let client = authenticated_client();
+
+    // First, set a known state.
+    client
+        .patch(format!("{}/api/notifications/preferences", BASE_URL))
+        .json(&json!({ "email_monthly_stats": false }))
+        .send()
+        .await
+        .unwrap();
+
+    // PATCH with empty body — must not reset to defaults.
+    let response = client
+        .patch(format!("{}/api/notifications/preferences", BASE_URL))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(
+        body["email_monthly_stats"].as_bool().unwrap(),
+        false,
+        "empty PATCH must not reset email_monthly_stats"
+    );
+
+    // Restore state
+    client
+        .patch(format!("{}/api/notifications/preferences", BASE_URL))
+        .json(&json!({ "email_monthly_stats": true }))
+        .send()
+        .await
+        .unwrap();
+}
+
+// ── POST /api/admin/cron/trigger-monthly-stats ────────────────────────────────
+
+#[tokio::test]
+async fn test_cron_trigger_requires_auth() {
+    let client = test_client();
+
+    let response = client
+        .post(format!("{}/api/admin/cron/trigger-monthly-stats", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_cron_trigger_requires_admin_role() {
+    // The billing test user is a regular (non-admin) member created by the
+    // test harness. They should get 403 from this endpoint.
+    let client = billing_test_client();
+
+    let response = client
+        .post(format!("{}/api/admin/cron/trigger-monthly-stats", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "non-admin user must receive 403 from cron trigger endpoint"
+    );
+}
+
+#[tokio::test]
+async fn test_cron_trigger_admin_returns_sent_errors_shape() {
+    let client = authenticated_client();
+
+    let response = client
+        .post(format!("{}/api/admin/cron/trigger-monthly-stats", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    let status = response.status();
+
+    // The admin test user may or may not be an admin depending on the
+    // environment; if not admin, skip rather than hard-fail.
+    if status == StatusCode::FORBIDDEN {
+        println!("Test user is not an admin - skipping cron trigger response shape test");
+        return;
+    }
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "admin cron trigger should return 200"
+    );
+
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    assert!(
+        body.is_object(),
+        "cron trigger response must be a JSON object, got: {:?}",
+        body
+    );
+    assert!(
+        body["sent"].is_number(),
+        "response must contain numeric 'sent' field, got: {:?}",
+        body
+    );
+    assert!(
+        body["errors"].is_number(),
+        "response must contain numeric 'errors' field, got: {:?}",
+        body
+    );
+
+    // In the test environment Mailgun is not configured, so the job exits
+    // early and returns (0, 0). This is the expected fast-path.
+    assert_eq!(
+        body["sent"].as_i64().unwrap(),
+        0,
+        "sent count should be 0 when Mailgun is not configured in test env"
+    );
+    assert_eq!(
+        body["errors"].as_i64().unwrap(),
+        0,
+        "error count should be 0 when Mailgun is not configured in test env"
+    );
+}

--- a/tests/settings_test.rs
+++ b/tests/settings_test.rs
@@ -184,3 +184,140 @@ async fn test_update_settings_requires_auth() {
 
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
+
+// ── GET /api/settings (public endpoint) ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_public_settings_accessible_without_auth() {
+    // This endpoint has no authentication requirement — anyone can call it.
+    let client = test_client();
+
+    let response = client
+        .get(format!("{}/api/settings", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "public settings must be accessible without authentication"
+    );
+}
+
+#[tokio::test]
+async fn test_public_settings_contains_email_notifications_enabled() {
+    let client = test_client();
+
+    let response = client
+        .get(format!("{}/api/settings", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    assert!(
+        body.get("email_notifications_enabled").is_some(),
+        "public settings must include email_notifications_enabled, got: {:?}",
+        body
+    );
+    assert!(
+        body["email_notifications_enabled"].is_boolean(),
+        "email_notifications_enabled must be a boolean, got: {:?}",
+        body["email_notifications_enabled"]
+    );
+    // In the test environment MAILGUN_API_KEY and MAILGUN_DOMAIN are not set,
+    // so is_mailgun_configured() returns false.
+    assert_eq!(
+        body["email_notifications_enabled"].as_bool().unwrap(),
+        false,
+        "email_notifications_enabled should be false when Mailgun is not configured"
+    );
+}
+
+#[tokio::test]
+async fn test_public_settings_contains_required_fields() {
+    let client = test_client();
+
+    let response = client
+        .get(format!("{}/api/settings", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    // All fields that the frontend depends on must be present.
+    let required_fields = [
+        "founder_pricing_active",
+        "email_notifications_enabled",
+        "active_discount_amount_pro_monthly",
+        "active_discount_amount_pro_annual",
+        "active_discount_amount_business_monthly",
+        "active_discount_amount_business_annual",
+    ];
+
+    for field in required_fields {
+        assert!(
+            body.get(field).is_some(),
+            "public settings must include '{field}', got: {:?}",
+            body
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_public_settings_discount_amounts_are_numbers() {
+    let client = test_client();
+
+    let response = client
+        .get(format!("{}/api/settings", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    let amount_fields = [
+        "active_discount_amount_pro_monthly",
+        "active_discount_amount_pro_annual",
+        "active_discount_amount_business_monthly",
+        "active_discount_amount_business_annual",
+    ];
+
+    for field in amount_fields {
+        assert!(
+            body[field].is_number(),
+            "'{field}' must be a number, got: {:?}",
+            body[field]
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_public_settings_founder_pricing_is_boolean() {
+    let client = test_client();
+
+    let response = client
+        .get(format!("{}/api/settings", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+
+    assert!(
+        body["founder_pricing_active"].is_boolean(),
+        "founder_pricing_active must be a boolean, got: {:?}",
+        body["founder_pricing_active"]
+    );
+}

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -22,8 +22,9 @@ command = "cargo install -q worker-build && worker-build --release"
 # Format: array of cron expressions (Cloudflare doesn't support named triggers)
 # - "0 0 * * *" = midnight UTC daily (subscription downgrade)
 # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
+# - "0 8 2 * *" = 8 AM UTC on day 2 of each month (monthly stats email)
 [triggers]
-crons = ["0 0 * * *", "0 4 * * *"]
+crons = ["0 0 * * *", "0 4 * * *", "0 8 2 * *"]
 
 # KV Namespace for URL mappings
 # Run: wrangler kv:namespace create "URL_MAPPINGS"
@@ -92,3 +93,7 @@ not_found_handling = "none"
 # ─── Polar secrets ───────────────────────────────────────────────────────────
 # wrangler secret put POLAR_ACCESS_TOKEN        (from Polar Dashboard → Settings → API)
 # wrangler secret put INTERNAL_WEBHOOK_SECRET   (generate: openssl rand -base64 32)
+#
+# ─── Mailgun secrets (optional, required for email features) ─────────────────
+# Without these, invitation emails and monthly stats emails are disabled.
+# wrangler secret put MAILGUN_API_KEY           (from Mailgun Dashboard → API Keys)


### PR DESCRIPTION
- Add notification_preferences table (migration 0033) with per-user email opt-in flags; missing row = opted in by default
- Add GET/PATCH /api/notifications/preferences API endpoints
- Add send_monthly_stats_email() with HTML + plain-text templates covering three states: no links, zero clicks, has clicks
- Add email_notification_service that runs on "0 8 2 * *" (day 2, 8 AM UTC), iterates opted-in owner users, builds per-org summaries and sends one aggregated email per user
- Extend /api/settings to expose email_notifications_enabled flag (true only when MAILGUN_API_KEY + MAILGUN_DOMAIN are configured)
- Add Email Notifications section in Settings page with monthly stats toggle; section is hidden when Mailgun is not configured
- Update cron triggers in wrangler.example.toml and all three deploy workflows (production, staging, ephemeral)

Closes #253 