### PR TITLE
feat: allow users to select and edit org scope for API keys

### DIFF
--- a/.github/workflows/deploy-ephemeral.yml
+++ b/.github/workflows/deploy-ephemeral.yml
@@ -250,7 +250,7 @@ jobs:
           # NOTE: Custom domain polling is done manually via admin panel
           # in ephemeral/staging due to cron trigger limits.
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *", "0 8 2 * *"]
+          crons = ["0 0 * * *", "0 4 * * *"]
 
           [[d1_databases]]
           binding = "rushomon"

--- a/docs/openapi/main.json
+++ b/docs/openapi/main.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Rushomon URL Shortener API",
-    "description": "API documentation for the Rushomon URL shortener service.\n\n## Authentication\n\nMost endpoints require authentication using either:\n- **Session cookies** (for web application users)\n- **Bearer tokens** (for API keys)\n\n### Using API Keys\n\n1. Create an API key in the dashboard (Pro tier or higher required)\n2. Include the key in the Authorization header:\n   ```\n   Authorization: Bearer ro_pat_...\n   ```\n## Response Format\n\nAll responses are JSON formatted. Error responses follow this structure:\n```json\n{\n  \"error\": \"Error message describing what went wrong\"\n}\n```\n\n## Pagination\n\nList endpoints support pagination with `page` and `limit` query parameters:\n- `page`: Page number (1-indexed, default: 1)\n- `limit`: Items per page (1-100, default: 20)\n",
+    "description": "API documentation for the Rushomon URL shortener service.\n\n## Authentication\n\nMost endpoints require authentication using either:\n- **Session cookies** (for web application users)\n- **Bearer tokens** (for API keys)\n\n### Using API Keys\n\n1. Create an API key in the dashboard (Pro tier or higher required)\n2. Include the key in the Authorization header:\n   ```\n   Authorization: Bearer ro_pat_...\n   ```\n\n### Multi-Organization API Keys\n\nAPI keys can be scoped to specific organizations. When using a multi-org key, you must specify the target organization using the `X-Org-Id` header:\n\n```\nAuthorization: Bearer ro_pat_...\nX-Org-Id: org-uuid-here\n```\n\n- **Single-org keys**: The `X-Org-Id` header is optional. If omitted, the key acts on its single authorized organization.\n- **Multi-org keys**: The `X-Org-Id` header is required. The header value must match one of the org IDs in the key's scope.\n- **Legacy keys (no scope)**: These keys act on the organization they were created on. The `X-Org-Id` header is not supported.\n\nIf you attempt to use a multi-org key without the `X-Org-Id` header, or with an org ID outside the key's scope, you will receive a 400 or 403 error.\n## Response Format\n\nAll responses are JSON formatted. Error responses follow this structure:\n```json\n{\n  \"error\": \"Error message describing what went wrong\"\n}\n```\n\n## Pagination\n\nList endpoints support pagination with `page` and `limit` query parameters:\n- `page`: Page number (1-indexed, default: 1)\n- `limit`: Items per page (1-100, default: 20)\n",
     "contact": {
       "name": "Rushomon Support",
       "email": "support@rushomon.cc"
@@ -1939,123 +1939,6 @@
         ]
       }
     },
-    "/api/keys": {
-      "get": {
-        "tags": [
-          "API Keys"
-        ],
-        "summary": "List API keys",
-        "description": "Returns all active API keys for the authenticated user. The raw token is never returned here — only the hint (last 4 chars)",
-        "operationId": "handle_list_api_keys",
-        "responses": {
-          "200": {
-            "description": "Array of active API keys"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          },
-          {
-            "session_cookie": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "API Keys"
-        ],
-        "summary": "Create an API key",
-        "description": "Generates a new personal access token (PAT) for programmatic API access. The raw token is returned only once — copy it immediately. Requires Pro tier or higher",
-        "operationId": "handle_create_api_key",
-        "requestBody": {
-          "description": "API key creation payload",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateApiKeyRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "API key created with raw token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateApiKeyResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Empty name"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Plan does not support API keys"
-          },
-          "404": {
-            "description": "Organization not found"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          },
-          {
-            "session_cookie": []
-          }
-        ]
-      }
-    },
-    "/api/keys/{id}": {
-      "delete": {
-        "tags": [
-          "API Keys"
-        ],
-        "summary": "Revoke an API key",
-        "description": "Soft-deletes an API key owned by the authenticated user. Returns 204 on success",
-        "operationId": "handle_revoke_api_key",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "API key ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Key revoked"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Key not found or not owned by user"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          },
-          {
-            "session_cookie": []
-          }
-        ]
-      }
-    },
     "/api/links": {
       "get": {
         "tags": [
@@ -3121,6 +3004,177 @@
         }
       }
     },
+    "/api/settings/api-keys": {
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "List API keys",
+        "description": "Returns all active API keys for the authenticated user. The raw token is never returned here — only the hint (last 4 chars). Includes `org_ids` showing which organizations each key is scoped to.",
+        "operationId": "handle_list_api_keys",
+        "responses": {
+          "200": {
+            "description": "Array of active API keys"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          },
+          {
+            "session_cookie": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Create an API key",
+        "description": "Generates a new personal access token (PAT) for programmatic API access. The raw token is returned only once — copy it immediately. Requires Pro tier or higher. Supply `org_ids` to restrict the key to specific organizations; omit to allow all orgs.",
+        "operationId": "handle_create_api_key",
+        "requestBody": {
+          "description": "API key creation payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateApiKeyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "API key created with raw token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateApiKeyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Empty name or invalid org IDs"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Plan does not support API keys"
+          },
+          "404": {
+            "description": "Organization not found"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          },
+          {
+            "session_cookie": []
+          }
+        ]
+      }
+    },
+    "/api/settings/api-keys/{id}": {
+      "delete": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Revoke an API key",
+        "description": "Soft-deletes an API key owned by the authenticated user. Returns 204 on success",
+        "operationId": "handle_revoke_api_key",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "API key ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Key revoked"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Key not found or not owned by user"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          },
+          {
+            "session_cookie": []
+          }
+        ]
+      }
+    },
+    "/api/settings/api-keys/{id}/orgs": {
+      "put": {
+        "tags": [
+          "API Keys"
+        ],
+        "summary": "Update an API key's org scope",
+        "description": "Replaces the list of organizations an API key is authorized to act on behalf of. The user must own the key and be a member of all supplied orgs. Requires at least one org.",
+        "operationId": "handle_update_api_key_orgs",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "API key ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "New org scope",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateApiKeyOrgsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Org scope updated"
+          },
+          "400": {
+            "description": "Empty org list or org not in membership"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Key not found or not owned by user"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          },
+          {
+            "session_cookie": []
+          }
+        ]
+      }
+    },
     "/api/settings/public": {
       "get": {
         "tags": [
@@ -3369,6 +3423,13 @@
             ],
             "format": "int64",
             "example": 30
+          },
+          "org_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional list of org IDs this key is allowed to act on behalf of.\nDefaults to all orgs the user belongs to when omitted or empty."
           }
         }
       },
@@ -3379,7 +3440,8 @@
           "name",
           "hint",
           "raw_token",
-          "created_at"
+          "created_at",
+          "org_ids"
         ],
         "properties": {
           "id": {
@@ -3411,6 +3473,13 @@
             ],
             "format": "int64",
             "example": 1612137600
+          },
+          "org_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The org IDs this key is authorized to act on behalf of."
           }
         }
       },
@@ -4167,6 +4236,21 @@
             ],
             "description": "Custom domain this link belongs to, if any.",
             "example": "go.mybrand.com"
+          }
+        }
+      },
+      "UpdateApiKeyOrgsRequest": {
+        "type": "object",
+        "required": [
+          "org_ids"
+        ],
+        "properties": {
+          "org_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Non-empty list of org IDs this key should be scoped to."
           }
         }
       },

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -151,6 +151,13 @@ export class ApiClient {
     });
   }
 
+  async put<T>(endpoint: string, data?: unknown): Promise<T> {
+    return this.request<T>(endpoint, {
+      method: "PUT",
+      body: data ? JSON.stringify(data) : undefined
+    });
+  }
+
   async delete<T>(endpoint: string, data?: unknown): Promise<T> {
     return this.request<T>(endpoint, {
       method: "DELETE",

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -7,6 +7,8 @@ export interface ApiKey {
   created_at: number;
   last_used_at: number | null;
   expires_at: number | null;
+  /** Org IDs this key is authorized to act on behalf of. Empty = legacy (all orgs). */
+  org_ids: string[];
 }
 
 export interface ApiKeyCreateResponse extends ApiKey {
@@ -16,11 +18,17 @@ export interface ApiKeyCreateResponse extends ApiKey {
 export const apiKeysApi = {
   list: () => apiClient.get<ApiKey[]>("/api/settings/api-keys"),
 
-  create: (name: string, expires_in_days: number | null) =>
+  create: (name: string, expires_in_days: number | null, org_ids: string[]) =>
     apiClient.post<ApiKeyCreateResponse>("/api/settings/api-keys", {
       name,
-      expires_in_days
+      expires_in_days,
+      org_ids
     }),
 
-  revoke: (id: string) => apiClient.delete(`/api/settings/api-keys/${id}`)
+  revoke: (id: string) => apiClient.delete(`/api/settings/api-keys/${id}`),
+
+  updateOrgs: (id: string, org_ids: string[]) =>
+    apiClient.put<{ success: boolean }>(`/api/settings/api-keys/${id}/orgs`, {
+      org_ids
+    })
 };

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -34,10 +34,17 @@
   let isDeletingKey = $state(false);
   let newKeyName = $state("");
   let newKeyExpires = $state<number | null>(30); // Default 30 days
+  let newKeySelectedOrgIds = $state<string[]>([]); // populated when modal opens
   let newlyGeneratedToken = $state<string | null>(null);
   let isCreatingKey = $state(false);
   let createError = $state<string | null>(null);
   let copySuccess = $state(false);
+
+  // Edit-scope modal state
+  let editScopeKey = $state<ApiKey | null>(null);
+  let editScopeOrgIds = $state<string[]>([]);
+  let isSavingScope = $state(false);
+  let editScopeError = $state<string | null>(null);
 
   // Email notification feature flag (from public settings)
   let emailNotificationsEnabled = $state(false);
@@ -131,12 +138,35 @@
     return billingStatus.tier !== "free";
   });
 
+  function openCreateModal() {
+    // Pre-select all orgs by default
+    newKeySelectedOrgIds = userOrgs.map((o) => o.id);
+    newKeyName = "";
+    newKeyExpires = 30;
+    newlyGeneratedToken = null;
+    createError = null;
+    copySuccess = false;
+    isCreateModalOpen = true;
+  }
+
+  function toggleCreateOrgSelection(orgId: string) {
+    if (newKeySelectedOrgIds.includes(orgId)) {
+      newKeySelectedOrgIds = newKeySelectedOrgIds.filter((id) => id !== orgId);
+    } else {
+      newKeySelectedOrgIds = [...newKeySelectedOrgIds, orgId];
+    }
+  }
+
   async function handleCreateKey() {
     if (!newKeyName.trim()) return;
     isCreatingKey = true;
     createError = null;
     try {
-      const res = await apiKeysApi.create(newKeyName, newKeyExpires);
+      const res = await apiKeysApi.create(
+        newKeyName,
+        newKeyExpires,
+        newKeySelectedOrgIds
+      );
       newlyGeneratedToken = res.raw_token;
       // Refresh the list immediately
       apiKeys = await apiKeysApi.list();
@@ -156,8 +186,42 @@
     }
   }
 
-  async function handleRevokeKey(id: string) {
+  function handleRevokeKey(id: string) {
     keyToDelete = id;
+  }
+
+  function openEditScope(key: ApiKey) {
+    editScopeKey = key;
+    // Pre-populate with current org IDs; fall back to all user orgs if empty (legacy key)
+    editScopeOrgIds =
+      key.org_ids.length > 0 ? [...key.org_ids] : userOrgs.map((o) => o.id);
+    editScopeError = null;
+  }
+
+  function toggleEditScopeOrg(orgId: string) {
+    if (editScopeOrgIds.includes(orgId)) {
+      editScopeOrgIds = editScopeOrgIds.filter((id) => id !== orgId);
+    } else {
+      editScopeOrgIds = [...editScopeOrgIds, orgId];
+    }
+  }
+
+  async function handleSaveScope() {
+    if (!editScopeKey || editScopeOrgIds.length === 0) return;
+    isSavingScope = true;
+    editScopeError = null;
+    try {
+      await apiKeysApi.updateOrgs(editScopeKey.id, editScopeOrgIds);
+      // Update the local state immediately
+      apiKeys = apiKeys.map((k) =>
+        k.id === editScopeKey!.id ? { ...k, org_ids: editScopeOrgIds } : k
+      );
+      editScopeKey = null;
+    } catch {
+      editScopeError = "Failed to update scope. Please try again.";
+    } finally {
+      isSavingScope = false;
+    }
   }
 
   async function confirmRevokeKey() {
@@ -323,13 +387,7 @@
             </div>
             {#if canCreateApiKeys()}
               <button
-                onclick={() => {
-                  isCreateModalOpen = true;
-                  newlyGeneratedToken = null;
-                  newKeyName = "";
-                  createError = null;
-                  copySuccess = false;
-                }}
+                onclick={openCreateModal}
                 class="px-4 py-2 bg-gradient-to-r from-orange-500 to-orange-600 text-white text-sm font-medium rounded-lg hover:from-orange-600 hover:to-orange-700 transition-all shadow-sm"
               >
                 Generate New Key
@@ -377,28 +435,52 @@
           {:else}
             <ul class="divide-y divide-gray-100 border-t border-gray-100">
               {#each apiKeys as key (key.id)}
-                <li
-                  class="flex items-center justify-between py-4 first:pt-4 last:pb-0"
-                >
-                  <div>
-                    <p class="text-sm font-medium text-gray-900">
-                      {key.name}
-                    </p>
-                    <p class="text-xs text-gray-500 font-mono mt-1">
-                      {key.hint}
-                    </p>
-                    <p class="text-xs text-gray-400 mt-1.5">
-                      Created {formatDate(key.created_at)}
-                      {#if key.last_used_at}
-                        • Last used {formatDate(key.last_used_at)}{/if}
-                    </p>
+                <li class="py-4 first:pt-4 last:pb-0">
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="min-w-0">
+                      <p class="text-sm font-medium text-gray-900">
+                        {key.name}
+                      </p>
+                      <p class="text-xs text-gray-500 font-mono mt-1">
+                        {key.hint}
+                      </p>
+                      {#if userOrgs.length > 1}
+                        <p class="text-xs text-gray-400 mt-1">
+                          {#if key.org_ids.length === 0}
+                            All organizations
+                          {:else}
+                            {key.org_ids
+                              .map(
+                                (id) =>
+                                  userOrgs.find((o) => o.id === id)?.name ?? id
+                              )
+                              .join(", ")}
+                          {/if}
+                        </p>
+                      {/if}
+                      <p class="text-xs text-gray-400 mt-1">
+                        Created {formatDate(key.created_at)}
+                        {#if key.last_used_at}
+                          • Last used {formatDate(key.last_used_at)}{/if}
+                      </p>
+                    </div>
+                    <div class="flex items-center gap-2 flex-shrink-0">
+                      {#if userOrgs.length > 1}
+                        <button
+                          onclick={() => openEditScope(key)}
+                          class="text-xs text-gray-500 hover:text-gray-800 font-medium px-3 py-1.5 rounded-md bg-gray-50 hover:bg-gray-100 transition-colors"
+                        >
+                          Edit scope
+                        </button>
+                      {/if}
+                      <button
+                        onclick={() => handleRevokeKey(key.id)}
+                        class="text-xs text-red-600 hover:text-red-800 font-medium px-3 py-1.5 rounded-md bg-red-50 hover:bg-red-100 transition-colors"
+                      >
+                        Revoke
+                      </button>
+                    </div>
                   </div>
-                  <button
-                    onclick={() => handleRevokeKey(key.id)}
-                    class="text-xs text-red-600 hover:text-red-800 font-medium px-3 py-1.5 rounded-md bg-red-50 hover:bg-red-100 transition-colors"
-                  >
-                    Revoke
-                  </button>
                 </li>
               {/each}
             </ul>
@@ -655,6 +737,44 @@
               <option value={null}>Never expire</option>
             </select>
           </div>
+          {#if userOrgs.length > 1}
+            <div>
+              <p class="block text-sm font-medium text-gray-700 mb-2">
+                Organization scope
+              </p>
+              <p class="text-xs text-gray-500 mb-3">
+                Choose which organizations this key can act on behalf of.
+              </p>
+              <ul class="space-y-2">
+                {#each userOrgs as org (org.id)}
+                  <li>
+                    <label class="flex items-center gap-3 cursor-pointer group">
+                      <input
+                        type="checkbox"
+                        checked={newKeySelectedOrgIds.includes(org.id)}
+                        onchange={() => toggleCreateOrgSelection(org.id)}
+                        class="h-4 w-4 rounded border-gray-300 text-orange-500 focus:ring-orange-400"
+                      />
+                      <span
+                        class="text-sm text-gray-800 group-hover:text-gray-900"
+                        >{org.name}</span
+                      >
+                      <span
+                        class="text-xs px-1.5 py-0.5 rounded-full capitalize font-medium ml-auto {tierColors[
+                          org.tier
+                        ] ?? 'bg-gray-100 text-gray-600'}">{org.tier}</span
+                      >
+                    </label>
+                  </li>
+                {/each}
+              </ul>
+              {#if newKeySelectedOrgIds.length === 0}
+                <p class="text-xs text-red-600 mt-2">
+                  Select at least one organization.
+                </p>
+              {/if}
+            </div>
+          {/if}
         </div>
         <div class="flex justify-end gap-3 pt-2 border-t border-gray-100">
           <button
@@ -665,7 +785,9 @@
           </button>
           <button
             onclick={handleCreateKey}
-            disabled={!newKeyName.trim() || isCreatingKey}
+            disabled={!newKeyName.trim() ||
+              isCreatingKey ||
+              newKeySelectedOrgIds.length === 0}
             class="px-5 py-2 bg-gradient-to-r from-orange-500 to-orange-600 text-white text-sm font-medium rounded-lg hover:from-orange-600 hover:to-orange-700 transition-all shadow-sm flex items-center justify-center min-w-[120px] disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {#if isCreatingKey}
@@ -786,6 +908,130 @@
             Revoking...
           {:else}
             Revoke Key
+          {/if}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- Edit Scope Modal -->
+{#if editScopeKey}
+  <div
+    class="fixed inset-0 bg-gray-900/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+    role="button"
+    tabindex="0"
+    onclick={() => (editScopeKey = null)}
+    onkeydown={(e) => e.key === "Escape" && (editScopeKey = null)}
+  >
+    <div
+      class="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6"
+      onclick={(e) => e.stopPropagation()}
+      role="dialog"
+      aria-modal="true"
+      tabindex="0"
+      onkeydown={(e) => e.key === "Escape" && (editScopeKey = null)}
+    >
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-lg font-semibold text-gray-900">Edit Key Scope</h3>
+        <button
+          onclick={() => (editScopeKey = null)}
+          class="text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label="Close dialog"
+        >
+          <svg
+            class="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            ></path>
+          </svg>
+        </button>
+      </div>
+
+      <p class="text-sm text-gray-500 mb-4">
+        Choose which organizations <span class="font-medium text-gray-800"
+          >{editScopeKey.name}</span
+        > is allowed to act on behalf of.
+      </p>
+
+      {#if editScopeError}
+        <div class="bg-red-50 border border-red-200 rounded-lg p-3 mb-4">
+          <p class="text-sm text-red-700">{editScopeError}</p>
+        </div>
+      {/if}
+
+      <ul class="space-y-2 mb-6">
+        {#each userOrgs as org (org.id)}
+          <li>
+            <label class="flex items-center gap-3 cursor-pointer group">
+              <input
+                type="checkbox"
+                checked={editScopeOrgIds.includes(org.id)}
+                onchange={() => toggleEditScopeOrg(org.id)}
+                class="h-4 w-4 rounded border-gray-300 text-orange-500 focus:ring-orange-400"
+              />
+              <span class="text-sm text-gray-800 group-hover:text-gray-900"
+                >{org.name}</span
+              >
+              <span
+                class="text-xs px-1.5 py-0.5 rounded-full capitalize font-medium ml-auto {tierColors[
+                  org.tier
+                ] ?? 'bg-gray-100 text-gray-600'}">{org.tier}</span
+              >
+            </label>
+          </li>
+        {/each}
+      </ul>
+
+      {#if editScopeOrgIds.length === 0}
+        <p class="text-xs text-red-600 mb-4">
+          Select at least one organization.
+        </p>
+      {/if}
+
+      <div class="flex gap-3">
+        <button
+          onclick={() => (editScopeKey = null)}
+          disabled={isSavingScope}
+          class="flex-1 px-4 py-2.5 bg-gray-100 text-gray-900 font-medium rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Cancel
+        </button>
+        <button
+          onclick={handleSaveScope}
+          disabled={editScopeOrgIds.length === 0 || isSavingScope}
+          class="flex-1 px-4 py-2.5 bg-gradient-to-r from-orange-500 to-orange-600 text-white font-medium rounded-lg hover:from-orange-600 hover:to-orange-700 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
+        >
+          {#if isSavingScope}
+            <svg
+              class="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              ></circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
+            Saving...
+          {:else}
+            Save Scope
           {/if}
         </button>
       </div>

--- a/migrations/0034_api_key_orgs.sql
+++ b/migrations/0034_api_key_orgs.sql
@@ -1,0 +1,20 @@
+-- API Key Org Scope
+--
+-- Stores which organizations an API key is authorized to act on behalf of.
+-- A key with no rows in this table is treated as legacy and falls back to
+-- the org_id stored directly on the api_keys row (backward compatibility).
+--
+-- When a user leaves or is removed from an org:
+--   - Their key's row for that org is deleted (via ON DELETE CASCADE on org_id
+--     is NOT used here since a user leaving is not an org deletion — the org
+--     still exists; we handle removal explicitly in application code)
+--   - If a key ends up with zero allowed orgs it is automatically revoked
+
+CREATE TABLE api_key_orgs (
+    api_key_id TEXT NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+    org_id     TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    PRIMARY KEY (api_key_id, org_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_key_orgs_key ON api_key_orgs(api_key_id);
+CREATE INDEX IF NOT EXISTS idx_api_key_orgs_org ON api_key_orgs(org_id);

--- a/src/api/keys/user.rs
+++ b/src/api/keys/user.rs
@@ -10,6 +10,10 @@ pub struct CreateApiKeyRequest {
     pub name: String,
     #[schema(example = 30)]
     pub expires_in_days: Option<i64>,
+    /// Optional list of org IDs this key is allowed to act on behalf of.
+    /// Defaults to all orgs the user belongs to when omitted or empty.
+    #[serde(default)]
+    pub org_ids: Vec<String>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -27,18 +31,26 @@ pub struct CreateApiKeyResponse {
     pub created_at: i64,
     #[schema(example = 1612137600)]
     pub expires_at: Option<i64>,
+    /// The org IDs this key is authorized to act on behalf of.
+    pub org_ids: Vec<String>,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct UpdateApiKeyOrgsRequest {
+    /// Non-empty list of org IDs this key should be scoped to.
+    pub org_ids: Vec<String>,
 }
 
 #[utoipa::path(
     post,
-    path = "/api/keys",
+    path = "/api/settings/api-keys",
     tag = "API Keys",
     summary = "Create an API key",
-    description = "Generates a new personal access token (PAT) for programmatic API access. The raw token is returned only once — copy it immediately. Requires Pro tier or higher",
+    description = "Generates a new personal access token (PAT) for programmatic API access. The raw token is returned only once — copy it immediately. Requires Pro tier or higher. Supply `org_ids` to restrict the key to specific organizations; omit to allow all orgs.",
     request_body(content = CreateApiKeyRequest, description = "API key creation payload"),
     responses(
         (status = 200, description = "API key created with raw token", body = CreateApiKeyResponse),
-        (status = 400, description = "Empty name"),
+        (status = 400, description = "Empty name or invalid org IDs"),
         (status = 401, description = "Unauthorized"),
         (status = 403, description = "Plan does not support API keys"),
         (status = 404, description = "Organization not found"),
@@ -65,19 +77,23 @@ pub async fn handle_create_api_key(mut req: Request, ctx: RouteContext<()>) -> R
 
     let db = ctx.env.get_binding::<worker::d1::D1Database>("rushomon")?;
 
-    let (key_id, raw_token, hint, created_at, expires_at) = match ApiKeyService::new()
+    let (key_id, raw_token, hint, created_at, expires_at, org_ids) = match ApiKeyService::new()
         .create(
             &db,
             &user_ctx.user_id,
             &user_ctx.org_id,
             &body.name,
             body.expires_in_days,
+            body.org_ids,
         )
         .await
     {
         Ok(result) => result,
         Err(worker::Error::RustError(msg)) if msg.contains("Upgrade to Pro") => {
             return Response::error(msg, 403);
+        }
+        Err(worker::Error::RustError(msg)) if msg.contains("not in your membership list") => {
+            return Response::error(msg, 400);
         }
         Err(e) => return Err(e),
     };
@@ -89,16 +105,17 @@ pub async fn handle_create_api_key(mut req: Request, ctx: RouteContext<()>) -> R
         "hint": hint,
         "raw_token": raw_token,
         "created_at": created_at,
-        "expires_at": expires_at
+        "expires_at": expires_at,
+        "org_ids": org_ids
     }))
 }
 
 #[utoipa::path(
     get,
-    path = "/api/keys",
+    path = "/api/settings/api-keys",
     tag = "API Keys",
     summary = "List API keys",
-    description = "Returns all active API keys for the authenticated user. The raw token is never returned here — only the hint (last 4 chars)",
+    description = "Returns all active API keys for the authenticated user. The raw token is never returned here — only the hint (last 4 chars). Includes `org_ids` showing which organizations each key is scoped to.",
     responses(
         (status = 200, description = "Array of active API keys"),
         (status = 401, description = "Unauthorized"),
@@ -121,7 +138,7 @@ pub async fn handle_list_api_keys(req: Request, ctx: RouteContext<()>) -> Result
 
 #[utoipa::path(
     delete,
-    path = "/api/keys/{id}",
+    path = "/api/settings/api-keys/{id}",
     tag = "API Keys",
     summary = "Revoke an API key",
     description = "Soft-deletes an API key owned by the authenticated user. Returns 204 on success",
@@ -154,4 +171,64 @@ pub async fn handle_revoke_api_key(req: Request, ctx: RouteContext<()>) -> Resul
         .await?;
 
     Ok(Response::empty()?.with_status(204))
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/settings/api-keys/{id}/orgs",
+    tag = "API Keys",
+    summary = "Update an API key's org scope",
+    description = "Replaces the list of organizations an API key is authorized to act on behalf of. The user must own the key and be a member of all supplied orgs. Requires at least one org.",
+    params(
+        ("id" = String, Path, description = "API key ID"),
+    ),
+    request_body(content = UpdateApiKeyOrgsRequest, description = "New org scope"),
+    responses(
+        (status = 200, description = "Org scope updated"),
+        (status = 400, description = "Empty org list or org not in membership"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Key not found or not owned by user"),
+    ),
+    security(
+        ("Bearer" = []),
+        ("session_cookie" = [])
+    )
+)]
+pub async fn handle_update_api_key_orgs(
+    mut req: Request,
+    ctx: RouteContext<()>,
+) -> Result<Response> {
+    let user_ctx = match authenticate_request(&req, &ctx).await {
+        Ok(ctx) => ctx,
+        Err(e) => return Ok(e.into_response()),
+    };
+
+    let key_id = ctx
+        .param("id")
+        .ok_or_else(|| Error::RustError("Missing ID".to_string()))?
+        .to_string();
+
+    let body: UpdateApiKeyOrgsRequest = match req.json().await {
+        Ok(b) => b,
+        Err(_) => return Response::error("Invalid request body", 400),
+    };
+
+    let db = ctx.env.get_binding::<worker::d1::D1Database>("rushomon")?;
+
+    match ApiKeyService::new()
+        .update_orgs(&db, &key_id, &user_ctx.user_id, body.org_ids)
+        .await
+    {
+        Ok(()) => Response::from_json(&serde_json::json!({ "success": true })),
+        Err(worker::Error::RustError(msg)) if msg.contains("at least one organization") => {
+            Response::error(msg, 400)
+        }
+        Err(worker::Error::RustError(msg)) if msg.contains("not in your membership list") => {
+            Response::error(msg, 400)
+        }
+        Err(worker::Error::RustError(msg)) if msg.contains("not found or not owned") => {
+            Response::error(msg, 404)
+        }
+        Err(e) => Err(e),
+    }
 }

--- a/src/api/orgs/members.rs
+++ b/src/api/orgs/members.rs
@@ -2,7 +2,7 @@
 ///
 /// DELETE /api/orgs/{id}/members/{user_id} - Remove a member
 use crate::auth;
-use crate::services::OrgService;
+use crate::services::{ApiKeyService, OrgService};
 use crate::utils::AppError;
 use worker::d1::D1Database;
 use worker::*;
@@ -49,6 +49,23 @@ async fn inner_remove_member(req: Request, ctx: RouteContext<()>) -> Result<Resp
     OrgService::new()
         .remove_member(&db, &org_id, &user_ctx.user_id, &target_user_id)
         .await?;
+
+    // Auto-revoke API keys scoped exclusively to this org for the removed user.
+    if let Err(e) = ApiKeyService::new()
+        .handle_user_removed_from_org(&db, &target_user_id, &org_id)
+        .await
+    {
+        worker::console_log!(
+            "{}",
+            serde_json::json!({
+                "event": "api_key_auto_revoke_failed",
+                "user_id": target_user_id,
+                "org_id": org_id,
+                "error": e.to_string(),
+                "level": "warn"
+            })
+        );
+    }
 
     Ok(Response::ok("Member removed")?)
 }

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -305,6 +305,10 @@ pub async fn run(req: Request, env: Env, is_frontend_domain: bool) -> Result<Res
             "/api/settings/api-keys/:id",
             crate::api::keys::handle_revoke_api_key,
         )
+        .put_async(
+            "/api/settings/api-keys/:id/orgs",
+            crate::api::keys::handle_update_api_key_orgs,
+        )
         // Custom domain routes (Pro+ feature)
         .get_async(
             "/api/orgs/:id/domains",

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -179,7 +179,43 @@ pub async fn authenticate_request(
             return Err(AuthError::Forbidden("Account suspended".to_string()));
         }
 
-        // 7. Update the 'last_used_at' timestamp
+        // 7. Resolve the active org from the key's scope + optional X-Org-Id header.
+        let allowed_orgs = match api_key_repo.get_key_orgs(&db, &api_key_with_tier.id).await {
+            Ok(orgs) => orgs,
+            Err(e) => {
+                console_log!("Failed to fetch API key org scope: {:?}", e);
+                return Err(AuthError::InternalError(
+                    "Failed to validate API key scope".to_string(),
+                ));
+            }
+        };
+
+        let x_org_header: Option<String> = req.headers().get("X-Org-Id").ok().flatten();
+
+        let resolved_org_id = if allowed_orgs.is_empty() {
+            // Legacy key: no rows in api_key_orgs → use the org_id stored on the key itself.
+            api_key_with_tier.org_id.clone()
+        } else if let Some(header_org) = x_org_header {
+            // Caller specified a target org — validate it's in the allowed list.
+            if !allowed_orgs.contains(&header_org) {
+                return Err(AuthError::Forbidden(format!(
+                    "This API key is not authorized to act on behalf of organization '{}'",
+                    header_org
+                )));
+            }
+            header_org
+        } else if allowed_orgs.len() == 1 {
+            // Exactly one allowed org and no header → use it implicitly.
+            allowed_orgs[0].clone()
+        } else {
+            // Multiple allowed orgs but no X-Org-Id header → ambiguous.
+            return Err(AuthError::Unauthorized(
+                "X-Org-Id header is required when an API key is scoped to multiple organizations"
+                    .to_string(),
+            ));
+        };
+
+        // 8. Update the 'last_used_at' timestamp
         if let Err(e) = api_key_repo
             .update_last_used(&db, &api_key_with_tier.id, now_timestamp())
             .await
@@ -187,10 +223,10 @@ pub async fn authenticate_request(
             console_log!("Failed to update API key last_used_at: {:?}", e);
         }
 
-        // 6. Successfully authenticate!
+        // 9. Successfully authenticate!
         return Ok(UserContext {
             user_id: user.id,
-            org_id: api_key_with_tier.org_id,
+            org_id: resolved_org_id,
             session_id: format!("pat_{}", api_key_with_tier.user_id),
             role: user.role,
         });

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -50,6 +50,7 @@ use utoipa::{Modify, OpenApi};
             // API Keys models
             crate::api::keys::CreateApiKeyRequest,
             crate::api::keys::CreateApiKeyResponse,
+            crate::api::keys::UpdateApiKeyOrgsRequest,
 
             // Version response
             crate::api::version::VersionResponse,
@@ -110,6 +111,7 @@ use utoipa::{Modify, OpenApi};
         crate::api::keys::handle_create_api_key,
         crate::api::keys::handle_list_api_keys,
         crate::api::keys::handle_revoke_api_key,
+        crate::api::keys::handle_update_api_key_orgs,
 
         // Billing
         crate::api::billing::handle_get_status,
@@ -212,6 +214,21 @@ Most endpoints require authentication using either:
    ```
    Authorization: Bearer ro_pat_...
    ```
+
+### Multi-Organization API Keys
+
+API keys can be scoped to specific organizations. When using a multi-org key, you must specify the target organization using the `X-Org-Id` header:
+
+```
+Authorization: Bearer ro_pat_...
+X-Org-Id: org-uuid-here
+```
+
+- **Single-org keys**: The `X-Org-Id` header is optional. If omitted, the key acts on its single authorized organization.
+- **Multi-org keys**: The `X-Org-Id` header is required. The header value must match one of the org IDs in the key's scope.
+- **Legacy keys (no scope)**: These keys act on the organization they were created on. The `X-Org-Id` header is not supported.
+
+If you attempt to use a multi-org key without the `X-Org-Id` header, or with an org ID outside the key's scope, you will receive a 400 or 403 error.
 ## Response Format
 
 All responses are JSON formatted. Error responses follow this structure:

--- a/src/repositories/api_key_repository.rs
+++ b/src/repositories/api_key_repository.rs
@@ -17,6 +17,17 @@ pub struct ApiKeyRecord {
     pub created_at: i64,
     pub last_used_at: Option<i64>,
     pub expires_at: Option<i64>,
+    /// The org IDs this key is authorized to act on behalf of.
+    /// Empty means the key is legacy and falls back to the org_id on the api_keys row.
+    #[serde(default)]
+    pub org_ids: Vec<String>,
+}
+
+/// Lightweight row used only to gather org IDs in a batch query.
+#[derive(Debug, Deserialize)]
+struct ApiKeyOrgRow {
+    pub api_key_id: String,
+    pub org_id: String,
 }
 
 /// API key record with tier information (for authentication).
@@ -290,8 +301,22 @@ impl ApiKeyRepository {
     }
 
     /// List active API keys for a specific user (no raw token returned).
+    ///
+    /// Fetches keys then batch-fetches their org scopes in a second query,
+    /// merging the results in Rust to avoid GROUP_CONCAT portability issues.
     pub async fn list_for_user(&self, db: &D1Database, user_id: &str) -> Result<Vec<ApiKeyRecord>> {
-        let results = db
+        // Temporary struct that deserialises the raw DB row (no org_ids yet).
+        #[derive(serde::Deserialize)]
+        struct KeyRow {
+            id: String,
+            name: String,
+            hint: String,
+            created_at: i64,
+            last_used_at: Option<i64>,
+            expires_at: Option<i64>,
+        }
+
+        let rows = db
             .prepare(
                 "SELECT id, name, hint, created_at, last_used_at, expires_at
                  FROM api_keys
@@ -300,8 +325,199 @@ impl ApiKeyRepository {
             )
             .bind(&[user_id.into()])?
             .all()
+            .await?
+            .results::<KeyRow>()?;
+
+        if rows.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Build the IN-list for the batch org-scope query.
+        let key_ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
+        let placeholders: String = key_ids
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let org_sql = format!(
+            "SELECT api_key_id, org_id FROM api_key_orgs WHERE api_key_id IN ({})",
+            placeholders
+        );
+        let bind_vals: Vec<worker::wasm_bindgen::JsValue> =
+            key_ids.iter().map(|id| id.as_str().into()).collect();
+
+        let org_rows = db
+            .prepare(&org_sql)
+            .bind(&bind_vals)?
+            .all()
+            .await?
+            .results::<ApiKeyOrgRow>()?;
+
+        // Build a map key_id → Vec<org_id>.
+        let mut org_map: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for row in org_rows {
+            org_map.entry(row.api_key_id).or_default().push(row.org_id);
+        }
+
+        Ok(rows
+            .into_iter()
+            .map(|r| {
+                let org_ids = org_map.remove(&r.id).unwrap_or_default();
+                ApiKeyRecord {
+                    id: r.id,
+                    name: r.name,
+                    hint: r.hint,
+                    created_at: r.created_at,
+                    last_used_at: r.last_used_at,
+                    expires_at: r.expires_at,
+                    org_ids,
+                }
+            })
+            .collect())
+    }
+
+    /// Return the list of allowed org IDs for a single key.
+    pub async fn get_key_orgs(&self, db: &D1Database, key_id: &str) -> Result<Vec<String>> {
+        let rows = db
+            .prepare("SELECT api_key_id, org_id FROM api_key_orgs WHERE api_key_id = ?1")
+            .bind(&[key_id.into()])?
+            .all()
+            .await?
+            .results::<ApiKeyOrgRow>()?;
+        Ok(rows.into_iter().map(|r| r.org_id).collect())
+    }
+
+    /// Replace all org-scope entries for a key (atomic delete + insert).
+    ///
+    /// Passing an empty slice clears all scopes (making the key legacy-fallback).
+    pub async fn set_key_orgs(
+        &self,
+        db: &D1Database,
+        key_id: &str,
+        org_ids: &[&str],
+    ) -> Result<()> {
+        // Delete existing rows.
+        db.prepare("DELETE FROM api_key_orgs WHERE api_key_id = ?1")
+            .bind(&[key_id.into()])?
+            .run()
             .await?;
-        results.results::<ApiKeyRecord>()
+
+        // Insert new rows individually (D1 does not support multi-row INSERT VALUES).
+        for org_id in org_ids {
+            db.prepare("INSERT INTO api_key_orgs (api_key_id, org_id) VALUES (?1, ?2)")
+                .bind(&[key_id.into(), (*org_id).into()])?
+                .run()
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Remove a specific org from all of a user's key scopes.
+    ///
+    /// Called when a user leaves / is removed from an org.
+    /// Returns the IDs of keys that now have zero allowed orgs (candidates for revocation).
+    pub async fn remove_org_from_user_keys(
+        &self,
+        db: &D1Database,
+        user_id: &str,
+        org_id: &str,
+    ) -> Result<Vec<String>> {
+        // Collect keys belonging to this user that are scoped to the given org.
+        #[derive(serde::Deserialize)]
+        struct IdRow {
+            id: String,
+        }
+
+        let affected_keys = db
+            .prepare(
+                "SELECT ak.id
+                 FROM api_keys ak
+                 JOIN api_key_orgs ako ON ako.api_key_id = ak.id
+                 WHERE ak.user_id = ?1 AND ako.org_id = ?2 AND ak.status = 'active'",
+            )
+            .bind(&[user_id.into(), org_id.into()])?
+            .all()
+            .await?
+            .results::<IdRow>()?;
+
+        if affected_keys.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Remove the org from those keys.
+        db.prepare(
+            "DELETE FROM api_key_orgs
+             WHERE org_id = ?1
+               AND api_key_id IN (
+                   SELECT ak.id FROM api_keys ak
+                   WHERE ak.user_id = ?2
+               )",
+        )
+        .bind(&[org_id.into(), user_id.into()])?
+        .run()
+        .await?;
+
+        // Find keys that now have zero org scopes (must be revoked).
+        let key_id_list: Vec<String> = affected_keys.iter().map(|r| r.id.clone()).collect();
+        let placeholders: String = key_id_list
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let empty_scope_sql = format!(
+            "SELECT ak.id
+             FROM api_keys ak
+             WHERE ak.id IN ({})
+               AND NOT EXISTS (
+                   SELECT 1 FROM api_key_orgs ako WHERE ako.api_key_id = ak.id
+               )",
+            placeholders
+        );
+        let bind_vals: Vec<worker::wasm_bindgen::JsValue> =
+            key_id_list.iter().map(|id| id.as_str().into()).collect();
+
+        let orphans = db
+            .prepare(&empty_scope_sql)
+            .bind(&bind_vals)?
+            .all()
+            .await?
+            .results::<IdRow>()?;
+
+        Ok(orphans.into_iter().map(|r| r.id).collect())
+    }
+
+    /// Revoke a list of keys via a system action (e.g. auto-revoke on org removal).
+    ///
+    /// Uses the sentinel `updated_by = 'system'` since there is no acting user.
+    pub async fn revoke_keys_system(&self, db: &D1Database, key_ids: &[String]) -> Result<()> {
+        let now = now_timestamp();
+        for key_id in key_ids {
+            db.prepare(
+                "UPDATE api_keys SET status = 'revoked', updated_at = ?1, updated_by = 'system'
+                 WHERE id = ?2 AND status = 'active'",
+            )
+            .bind(&[(now as f64).into(), key_id.as_str().into()])?
+            .run()
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Verify that a key is owned by the given user and return its current status.
+    pub async fn get_owner(&self, db: &D1Database, key_id: &str) -> Result<Option<String>> {
+        #[derive(serde::Deserialize)]
+        struct OwnerRow {
+            user_id: String,
+        }
+        Ok(db
+            .prepare("SELECT user_id FROM api_keys WHERE id = ?1")
+            .bind(&[key_id.into()])?
+            .first::<OwnerRow>(None)
+            .await?
+            .map(|r| r.user_id))
     }
 
     /// Soft-delete a key owned by the given user (status: active → deleted).

--- a/src/services/api_key_service.rs
+++ b/src/services/api_key_service.rs
@@ -4,9 +4,10 @@
 /// - Tier gating (Pro+ required)
 /// - Token generation and hashing
 /// - Ownership-scoped revocation
+/// - Org-scope management (set/update which orgs a key can act on behalf of)
 use crate::models::Tier;
 use crate::repositories::api_key_repository::ApiKeyRecord;
-use crate::repositories::{ApiKeyRepository, BillingRepository};
+use crate::repositories::{ApiKeyRepository, BillingRepository, OrgRepository};
 use crate::utils::{generate_short_code_with_length, now_timestamp};
 use hex;
 use sha2::{Digest, Sha256};
@@ -23,7 +24,10 @@ impl ApiKeyService {
     /// Create a new API key for the given user/org.
     ///
     /// Performs the tier check, generates the token + hash, and persists the record.
-    /// Returns `(key_id, raw_token, hint, created_at, expires_at)`.
+    /// `org_ids` is the list of orgs this key is allowed to act on behalf of.
+    /// When empty, defaults to all orgs the user currently belongs to.
+    ///
+    /// Returns `(key_id, raw_token, hint, created_at, expires_at, org_ids)`.
     /// The raw token is shown exactly once — callers must surface it to the user immediately.
     pub async fn create(
         &self,
@@ -32,8 +36,9 @@ impl ApiKeyService {
         org_id: &str,
         name: &str,
         expires_in_days: Option<i64>,
-    ) -> Result<(String, String, String, i64, Option<i64>)> {
-        // --- Tier gate ---
+        requested_org_ids: Vec<String>,
+    ) -> Result<(String, String, String, i64, Option<i64>, Vec<String>)> {
+        // --- Tier gate (check against the current session org) ---
         let billing_repo = BillingRepository::new();
         let tier = match billing_repo.get_billing_account_for_org(db, org_id).await? {
             Some(ba) => Tier::from_str_value(&ba.tier).unwrap_or(Tier::Free),
@@ -45,6 +50,31 @@ impl ApiKeyService {
                 "API keys are not available on your current plan. Upgrade to Pro or higher to use API keys.".to_string(),
             ));
         }
+
+        // --- Resolve org scope ---
+        // If the caller supplied a list, validate all are orgs the user actually belongs to.
+        // If the caller supplied nothing, default to all of the user's orgs.
+        let user_org_ids: Vec<String> = OrgRepository::new()
+            .get_user_orgs(db, user_id)
+            .await?
+            .into_iter()
+            .map(|o| o.id)
+            .collect();
+
+        let final_org_ids: Vec<String> = if requested_org_ids.is_empty() {
+            user_org_ids
+        } else {
+            // Validate all requested orgs are in the user's membership.
+            for req_org in &requested_org_ids {
+                if !user_org_ids.contains(req_org) {
+                    return Err(worker::Error::RustError(format!(
+                        "Organization '{}' is not in your membership list",
+                        req_org
+                    )));
+                }
+            }
+            requested_org_ids
+        };
 
         // --- Generate token ---
         let now = now_timestamp();
@@ -59,17 +89,22 @@ impl ApiKeyService {
 
         let key_id = uuid::Uuid::new_v4().to_string();
 
-        // --- Persist ---
-        ApiKeyRepository::new()
-            .create_for_user(
-                db, &key_id, user_id, org_id, name, &key_hash, &hint, now, expires_at,
-            )
-            .await?;
+        let repo = ApiKeyRepository::new();
 
-        Ok((key_id, raw_token, hint, now, expires_at))
+        // --- Persist key ---
+        repo.create_for_user(
+            db, &key_id, user_id, org_id, name, &key_hash, &hint, now, expires_at,
+        )
+        .await?;
+
+        // --- Persist org scope ---
+        let org_id_refs: Vec<&str> = final_org_ids.iter().map(|s| s.as_str()).collect();
+        repo.set_key_orgs(db, &key_id, &org_id_refs).await?;
+
+        Ok((key_id, raw_token, hint, now, expires_at, final_org_ids))
     }
 
-    /// List active API keys for the given user.
+    /// List active API keys for the given user (includes org_ids per key).
     pub async fn list(&self, db: &D1Database, user_id: &str) -> Result<Vec<ApiKeyRecord>> {
         ApiKeyRepository::new().list_for_user(db, user_id).await
     }
@@ -79,6 +114,75 @@ impl ApiKeyService {
         ApiKeyRepository::new()
             .revoke_for_user(db, key_id, user_id)
             .await
+    }
+
+    /// Update the org scope of an existing key owned by `user_id`.
+    ///
+    /// Validates that all supplied org IDs are in the user's current membership.
+    /// The org list must be non-empty (use `revoke` to deactivate a key instead).
+    pub async fn update_orgs(
+        &self,
+        db: &D1Database,
+        key_id: &str,
+        user_id: &str,
+        new_org_ids: Vec<String>,
+    ) -> Result<()> {
+        if new_org_ids.is_empty() {
+            return Err(worker::Error::RustError(
+                "org_ids must contain at least one organization".to_string(),
+            ));
+        }
+
+        // Verify ownership.
+        let owner = ApiKeyRepository::new().get_owner(db, key_id).await?;
+        match owner {
+            Some(owner_id) if owner_id == user_id => {}
+            _ => {
+                return Err(worker::Error::RustError(
+                    "API key not found or not owned by you".to_string(),
+                ));
+            }
+        }
+
+        // Validate membership for each requested org.
+        let user_org_ids: Vec<String> = OrgRepository::new()
+            .get_user_orgs(db, user_id)
+            .await?
+            .into_iter()
+            .map(|o| o.id)
+            .collect();
+
+        for req_org in &new_org_ids {
+            if !user_org_ids.contains(req_org) {
+                return Err(worker::Error::RustError(format!(
+                    "Organization '{}' is not in your membership list",
+                    req_org
+                )));
+            }
+        }
+
+        let org_refs: Vec<&str> = new_org_ids.iter().map(|s| s.as_str()).collect();
+        ApiKeyRepository::new()
+            .set_key_orgs(db, key_id, &org_refs)
+            .await
+    }
+
+    /// Handle a user being removed from an org.
+    ///
+    /// Removes `org_id` from that user's key scopes; keys that end up with zero
+    /// allowed orgs are automatically revoked with `updated_by = 'system'`.
+    pub async fn handle_user_removed_from_org(
+        &self,
+        db: &D1Database,
+        user_id: &str,
+        org_id: &str,
+    ) -> Result<()> {
+        let repo = ApiKeyRepository::new();
+        let keys_to_revoke = repo.remove_org_from_user_keys(db, user_id, org_id).await?;
+        if !keys_to_revoke.is_empty() {
+            repo.revoke_keys_system(db, &keys_to_revoke).await?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- Add api_key_orgs join table to store per-key org scope
- Multi-org keys require X-Org-Id header at request time; single-org keys use it implicitly; legacy keys (no rows) fall back to org_id
- New PUT /api/settings/api-keys/:id/orgs endpoint to update scope
- Auto-revoke keys that lose their last allowed org when user leaves
- Frontend: org selector in create modal, scope display in key list, edit-scope modal (UI only shown to multi-org users)

Closes #208 