### PR TITLE
feat(orgs): implement Owner/Admin/Member role system

### DIFF
--- a/docs-site/docs/permissions.md
+++ b/docs-site/docs/permissions.md
@@ -1,0 +1,86 @@
+---
+sidebar_position: 2
+---
+
+# Permissions & Tiers
+
+Rushomon uses a two-level permission model: **organization roles** (within an org) and **billing tiers** (feature limits). This page explains both.
+
+## Organization Roles
+
+Every user in an organization has one of three roles:
+
+| Role | Description |
+|------|-------------|
+| **Owner** | Full control over the organization. Can delete the org, manage billing, and change any member's role. The owner is the only person who can delete the organization. |
+| **Admin** | Can invite members, manage org settings, and promote/demote regular members. Cannot delete the org, change owner roles, or modify other admins. |
+| **Member** | Can create, edit, and delete links; view analytics. Cannot invite members, change settings, or manage custom domains. |
+
+### Permission Matrix
+
+| Operation | Owner | Admin | Member |
+|-----------|-------|-------|--------|
+| View org, list links, view analytics | ✅ | ✅ | ✅ |
+| Create / edit / delete links | ✅ | ✅ | ✅ |
+| Rename org | ✅ | ✅ | ❌ |
+| Manage org settings | ✅ | ✅ | ❌ |
+| Invite members (choose member or admin role) | ✅ | ✅ | ❌ |
+| Revoke / resend invitations | ✅ | ✅ | ❌ |
+| Remove members (members & admins, not owners) | ✅ | ✅ (non-owner targets) | ❌ (self only) |
+| Update member role (member ↔ admin) | ✅ | ✅ (can't touch owners or other admins) | ❌ |
+| Manage custom domains | ✅ | ✅ | ❌ |
+| Delete org | ✅ | ❌ | ❌ |
+| Billing / subscription changes | ✅ (owner-only) | ❌ | ❌ |
+
+### Key Rules
+
+- **Owner cannot be removed** via the member removal endpoint. The last owner of an org cannot be removed at all.
+- **Admins cannot change other admins' roles** — only owners can demote admins.
+- **Admins cannot remove owners or other admins** — they can only remove regular members.
+- **Nobody can assign the 'owner' role** via the role-update endpoint. Ownership transfer is a separate concern (not currently implemented).
+- **Billing/subscription changes are owner-only** — this is enforced at the service level because billing accounts are linked to the owner's user account.
+
+## Billing Tiers
+
+Rushomon offers four billing tiers that determine feature access and quotas:
+
+| Feature | Free | Pro | Business | Unlimited |
+|---------|------|-----|----------|-----------|
+| Links/month | 15 | 1,000 | 10,000 | ∞ |
+| Analytics retention | 7 days | 365 days | ∞ | ∞ |
+| Custom short codes | ❌ | ✅ | ✅ | ✅ |
+| UTM parameters | ❌ | ✅ | ✅ | ✅ |
+| Query forwarding | ❌ | ✅ | ✅ | ✅ |
+| Device routing | ❌ | ❌ | ✅ | ✅ |
+| API keys | ❌ | ✅ | ✅ | ✅ |
+| Max members | 1 | 1 | 20 | ∞ |
+| Max orgs | 1 | 1 | 3 | ∞ |
+| Max tags | 5 | 25 | ∞ | ∞ |
+| Custom domains | 0 | 1 | 3 | ∞ |
+
+### Tier Enforcement
+
+- **Link creation**: Checked against the monthly link quota for the org's tier.
+- **Member invitations**: Checked against the member limit (Business tier allows up to 20 members; Unlimited has no limit).
+- **API key creation**: Only available on Pro tier and higher.
+- **Analytics queries**: Free tier returns only the last 7 days of data; higher tiers have longer or unlimited retention.
+- **Custom domains**: Tier limits the number of domains per org.
+
+### Self-Hosting
+
+If you're self-hosting Rushomon, you can disable all tier limits by setting the `default_user_tier` system setting to `'unlimited'` in the database. This removes all quotas and feature restrictions.
+
+## Instance-Level vs Organization-Level
+
+Rushomon has a two-level permission model:
+
+1. **Instance-level roles** (`users.role` in the database):
+   - `admin`: Full system access (can manage all users, billing accounts, system settings, etc.)
+   - `member`: Regular user (default)
+
+2. **Organization-level roles** (`org_members.role` in the database):
+   - `owner`: Full org control
+   - `admin`: Org management (but not deletion)
+   - `member`: Regular org member
+
+Instance-level admins are intended for system administration (e.g., managing the managed service). Organization-level roles control access within a specific organization.

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -12,6 +12,11 @@ const sidebars: SidebarsConfig = {
       label: 'Getting Started',
     },
     {
+      type: 'doc',
+      id: 'permissions',
+      label: 'Permissions & Tiers',
+    },
+    {
       type: 'category',
       label: 'API',
       link: {

--- a/frontend/src/lib/api/orgs.ts
+++ b/frontend/src/lib/api/orgs.ts
@@ -1,13 +1,13 @@
-import { apiClient } from "./client";
 import type {
+  InviteInfo,
   ListOrgsResponse,
   OrgDetails,
-  OrgWithRole,
   OrgInvitation,
-  InviteInfo,
-  UsageResponse,
-  OrgSettings
+  OrgSettings,
+  OrgWithRole,
+  UsageResponse
 } from "$lib/types/api";
+import { apiClient } from "./client";
 
 export const orgsApi = {
   async listMyOrgs(): Promise<ListOrgsResponse> {
@@ -36,13 +36,12 @@ export const orgsApi = {
 
   async inviteMember(
     org_id: string,
-    email: string
+    email: string,
+    role: "member" | "admin" = "member"
   ): Promise<{ invitation: OrgInvitation }> {
     return apiClient.post<{ invitation: OrgInvitation }>(
       `/api/orgs/${org_id}/invitations`,
-      {
-        email
-      }
+      { email, role }
     );
   },
 
@@ -61,6 +60,17 @@ export const orgsApi = {
 
   async removeMember(org_id: string, user_id: string): Promise<void> {
     return apiClient.delete<void>(`/api/orgs/${org_id}/members/${user_id}`);
+  },
+
+  async updateMemberRole(
+    org_id: string,
+    user_id: string,
+    role: "member" | "admin"
+  ): Promise<{ role: string }> {
+    return apiClient.put<{ role: string }>(
+      `/api/orgs/${org_id}/members/${user_id}/role`,
+      { role }
+    );
   },
 
   async leaveOrg(org_id: string, user_id: string): Promise<void> {

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -302,7 +302,7 @@ export interface OrgWithRole {
   id: string;
   name: string;
   tier: string;
-  role: "owner" | "member";
+  role: "owner" | "admin" | "member";
   joined_at: number;
 }
 
@@ -311,7 +311,7 @@ export interface OrgMember {
   email: string;
   name: string | null;
   avatar_url: string | null;
-  role: "owner" | "member";
+  role: "owner" | "admin" | "member";
   joined_at: number;
 }
 
@@ -332,7 +332,7 @@ export interface OrgDetails {
     name: string;
     tier: string;
     created_at: number;
-    role: "owner" | "member";
+    role: "owner" | "admin" | "member";
     logo_url: string | null;
     link_count: number;
   };

--- a/frontend/src/routes/dashboard/org/+page.svelte
+++ b/frontend/src/routes/dashboard/org/+page.svelte
@@ -36,6 +36,7 @@
 
   // Invite member
   let inviteEmail = $state("");
+  let inviteRole = $state<"member" | "admin">("member");
   let inviting = $state(false);
   let inviteError = $state("");
   let inviteSuccess = $state("");
@@ -166,9 +167,10 @@
     inviteError = "";
     inviteSuccess = "";
     try {
-      await orgsApi.inviteMember(orgDetails.org.id, email);
-      inviteSuccess = `Invitation sent to ${email}.`;
+      await orgsApi.inviteMember(orgDetails.org.id, email, inviteRole);
+      inviteSuccess = `Invitation sent to ${email} as ${inviteRole}.`;
       inviteEmail = "";
+      inviteRole = "member";
       await loadOrg();
     } catch (e: unknown) {
       if (e instanceof Error) {
@@ -249,6 +251,30 @@
     confirmingRemoveMember = null;
   }
 
+  async function handleUpdateMemberRole(
+    member: OrgMember,
+    newRole: "member" | "admin"
+  ) {
+    if (!orgDetails || newRole === member.role) return;
+    updatingRoleMemberId = member.user_id;
+    actionError = "";
+    actionSuccess = "";
+    try {
+      await orgsApi.updateMemberRole(
+        orgDetails.org.id,
+        member.user_id,
+        newRole
+      );
+      actionSuccess = `${member.name ?? member.email}'s role updated to ${newRole}.`;
+      await loadOrg();
+      setTimeout(() => (actionSuccess = ""), 3000);
+    } catch (e: unknown) {
+      actionError = e instanceof Error ? e.message : "Failed to update role.";
+    } finally {
+      updatingRoleMemberId = null;
+    }
+  }
+
   function formatDate(ts: number): string {
     return new Date(ts * 1000).toLocaleDateString(undefined, {
       year: "numeric",
@@ -258,6 +284,8 @@
   }
 
   const isOwner = $derived(orgDetails?.org.role === "owner");
+  const isAdmin = $derived(orgDetails?.org.role === "admin");
+  const canManageMembers = $derived(isOwner || isAdmin);
   const isPro = $derived(
     ["pro", "business", "unlimited"].includes(orgDetails?.org.tier ?? "")
   );
@@ -525,6 +553,7 @@
   let deleting = $state(false);
   let deleteError = $state("");
   let confirmingRemoveMember = $state<OrgMember | null>(null);
+  let updatingRoleMemberId = $state<string | null>(null);
   let linkCount = $state(0);
   let userOrgs = $state<OrgWithRole[]>([]);
   let canDelete = $state(false);
@@ -982,15 +1011,38 @@
                 </div>
               </div>
               <div class="flex items-center gap-3">
-                <span
-                  class="text-xs font-medium capitalize px-2 py-0.5 rounded-full {member.role ===
-                  'owner'
-                    ? 'bg-orange-100 text-orange-700'
-                    : 'bg-gray-100 text-gray-600'}"
-                >
-                  {member.role}
-                </span>
-                {#if isOwner && member.user_id !== data.user?.id}
+                <!-- Role badge / selector -->
+                {#if canManageMembers && member.role !== "owner" && member.user_id !== data.user?.id && !(isAdmin && member.role === "admin")}
+                  <select
+                    value={member.role}
+                    disabled={updatingRoleMemberId === member.user_id}
+                    onchange={(e) =>
+                      handleUpdateMemberRole(
+                        member,
+                        (e.currentTarget as HTMLSelectElement).value as
+                          | "member"
+                          | "admin"
+                      )}
+                    class="text-xs font-medium px-2 py-0.5 rounded-full border border-gray-200 bg-white text-gray-700 cursor-pointer disabled:opacity-50"
+                    aria-label="Change role"
+                  >
+                    <option value="member">Member</option>
+                    <option value="admin">Admin</option>
+                  </select>
+                {:else}
+                  <span
+                    class="text-xs font-medium capitalize px-2 py-0.5 rounded-full {member.role ===
+                    'owner'
+                      ? 'bg-orange-100 text-orange-700'
+                      : member.role === 'admin'
+                        ? 'bg-blue-100 text-blue-700'
+                        : 'bg-gray-100 text-gray-600'}"
+                  >
+                    {member.role}
+                  </span>
+                {/if}
+                <!-- Remove button: owner can remove any non-self; admin can remove members (not owners/admins) -->
+                {#if member.user_id !== data.user?.id && (isOwner || (isAdmin && member.role === "member"))}
                   <button
                     onclick={() => handleRemoveMember(member)}
                     class="text-xs text-red-500 hover:text-red-700 transition-colors"
@@ -1005,8 +1057,8 @@
         </ul>
       </div>
 
-      <!-- Invite Card (owner only) -->
-      {#if isOwner}
+      <!-- Invite Card (owner or admin) -->
+      {#if canManageMembers}
         <div class="bg-white rounded-xl border border-gray-200 p-6 mb-6">
           <h2 class="text-lg font-semibold text-gray-900 mb-1">
             Invite Members
@@ -1044,6 +1096,14 @@
                   </p>
                 {/if}
               </div>
+              <select
+                bind:value={inviteRole}
+                class="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500 focus:border-orange-500 outline-none bg-white"
+                aria-label="Role for invitee"
+              >
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </select>
               <LoadingButton
                 onclick={handleInvite}
                 loading={inviting}
@@ -1065,6 +1125,12 @@
                       <div>
                         <p class="text-sm text-gray-900">
                           {inv.email}
+                          <span
+                            class="ml-1 text-xs font-medium capitalize px-1.5 py-0.5 rounded-full {inv.role ===
+                            'admin'
+                              ? 'bg-blue-100 text-blue-700'
+                              : 'bg-gray-100 text-gray-600'}">{inv.role}</span
+                          >
                         </p>
                         <p class="text-xs text-gray-500">
                           Expires {formatDate(inv.expires_at)}

--- a/migrations/0035_org_members_role_constraint.sql
+++ b/migrations/0035_org_members_role_constraint.sql
@@ -1,0 +1,35 @@
+-- Add CHECK constraint to org_members.role to enforce valid values
+-- SQLite does not support ALTER TABLE ADD CONSTRAINT, so we recreate the table.
+-- Valid roles: 'owner' | 'admin' | 'member'
+
+PRAGMA foreign_keys = OFF;
+
+-- 1. Drop existing indexes (they survive the table rename and would conflict on recreate)
+DROP INDEX IF EXISTS idx_org_members_user;
+DROP INDEX IF EXISTS idx_org_members_org;
+
+-- 2. Rename existing table
+ALTER TABLE org_members RENAME TO org_members_old;
+
+-- 3. Create new table with CHECK constraint
+CREATE TABLE org_members (
+  org_id    TEXT NOT NULL,
+  user_id   TEXT NOT NULL,
+  role      TEXT NOT NULL DEFAULT 'member' CHECK(role IN ('owner', 'admin', 'member')),
+  joined_at INTEGER NOT NULL,
+  PRIMARY KEY (org_id, user_id),
+  FOREIGN KEY (org_id)  REFERENCES organizations(id),
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- 4. Copy data (existing rows should only contain 'owner' or 'member')
+INSERT INTO org_members SELECT * FROM org_members_old;
+
+-- 5. Recreate indexes
+CREATE INDEX idx_org_members_user ON org_members(user_id);
+CREATE INDEX idx_org_members_org  ON org_members(org_id);
+
+-- 6. Drop old table
+DROP TABLE org_members_old;
+
+PRAGMA foreign_keys = ON;

--- a/src/api/orgs/invitations.rs
+++ b/src/api/orgs/invitations.rs
@@ -85,6 +85,16 @@ async fn inner_create_invitation(
         return Err(AppError::BadRequest("Invalid email address".to_string()));
     }
 
+    // Optional role for the invitee — defaults to 'member'. 'owner' is never allowed.
+    let invite_role = match body["role"].as_str().unwrap_or("member") {
+        r @ ("member" | "admin") => r.to_string(),
+        _ => {
+            return Err(AppError::BadRequest(
+                "Invite role must be 'member' or 'admin'".to_string(),
+            ));
+        }
+    };
+
     let user_repo = UserRepository::new();
     if let Some(existing_user) = user_repo.get_by_email(&db, &email).await?
         && repo
@@ -110,7 +120,7 @@ async fn inner_create_invitation(
         .unwrap_or(&inviter.email)
         .to_string();
     let invitation = repo
-        .create_invitation(&db, &org_id, &user_ctx.user_id, &email, "member")
+        .create_invitation(&db, &org_id, &user_ctx.user_id, &email, &invite_role)
         .await?;
 
     let frontend_url = get_frontend_url(&ctx.env);

--- a/src/api/orgs/members.rs
+++ b/src/api/orgs/members.rs
@@ -1,6 +1,7 @@
 /// Org member management handlers
 ///
-/// DELETE /api/orgs/{id}/members/{user_id} - Remove a member
+/// DELETE /api/orgs/{id}/members/{user_id}      - Remove a member
+/// PUT    /api/orgs/{id}/members/{user_id}/role  - Update a member's role
 use crate::auth;
 use crate::services::{ApiKeyService, OrgService};
 use crate::utils::AppError;
@@ -68,4 +69,65 @@ async fn inner_remove_member(req: Request, ctx: RouteContext<()>) -> Result<Resp
     }
 
     Ok(Response::ok("Member removed")?)
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/orgs/{id}/members/{user_id}/role",
+    tag = "Organizations",
+    summary = "Update a member's role",
+    description = "Changes a member's role within the organization. Owners can promote/demote any non-owner member. Admins can promote members to admin but cannot change the role of owners or other admins. Cannot change your own role. Role must be 'member' or 'admin' — ownership transfer is not supported via this endpoint.",
+    params(
+        ("id" = String, Path, description = "Organization ID"),
+        ("user_id" = String, Path, description = "User ID whose role to update"),
+    ),
+    responses(
+        (status = 200, description = "Role updated"),
+        (status = 400, description = "Invalid role value"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Insufficient permissions"),
+        (status = 404, description = "Member not found"),
+    ),
+    security(("Bearer" = []), ("session_cookie" = []))
+)]
+pub async fn handle_update_member_role(req: Request, ctx: RouteContext<()>) -> Result<Response> {
+    Ok(inner_update_member_role(req, ctx)
+        .await
+        .unwrap_or_else(|e| e.into_response()))
+}
+
+async fn inner_update_member_role(
+    mut req: Request,
+    ctx: RouteContext<()>,
+) -> Result<Response, AppError> {
+    let user_ctx = auth::authenticate_request(&req, &ctx).await?;
+
+    let org_id = ctx
+        .param("id")
+        .ok_or_else(|| AppError::BadRequest("Missing org id".to_string()))?
+        .to_string();
+    let target_user_id = ctx
+        .param("user_id")
+        .ok_or_else(|| AppError::BadRequest("Missing user_id".to_string()))?
+        .to_string();
+
+    let body: serde_json::Value = req
+        .json()
+        .await
+        .map_err(|_| AppError::BadRequest("Invalid JSON body".to_string()))?;
+
+    let new_role = body["role"]
+        .as_str()
+        .ok_or_else(|| AppError::BadRequest("'role' field is required".to_string()))?
+        .to_string();
+
+    let db = ctx.env.get_binding::<D1Database>("rushomon")?;
+
+    OrgService::new()
+        .update_member_role(&db, &org_id, &user_ctx.user_id, &target_user_id, &new_role)
+        .await?;
+
+    Ok(Response::from_json(
+        &serde_json::json!({ "role": new_role }),
+    )?)
 }

--- a/src/api/orgs/mod.rs
+++ b/src/api/orgs/mod.rs
@@ -22,5 +22,5 @@ pub use invitations::{
 };
 pub use list::{handle_list_user_orgs, handle_switch_org};
 pub use logo::{handle_delete_org_logo, handle_get_org_logo, handle_upload_org_logo};
-pub use members::handle_remove_member;
+pub use members::{handle_remove_member, handle_update_member_role};
 pub use settings::{handle_get_org_settings, handle_update_org_settings};

--- a/src/api/router.rs
+++ b/src/api/router.rs
@@ -344,6 +344,10 @@ pub async fn run(req: Request, env: Env, is_frontend_domain: bool) -> Result<Res
             "/api/orgs/:id/members/:user_id",
             crate::api::orgs::handle_remove_member,
         )
+        .put_async(
+            "/api/orgs/:id/members/:user_id/role",
+            crate::api::orgs::handle_update_member_role,
+        )
         .post_async(
             "/api/orgs/:id/invitations",
             crate::api::orgs::handle_create_invitation,

--- a/src/repositories/org_repository.rs
+++ b/src/repositories/org_repository.rs
@@ -307,6 +307,22 @@ impl OrgRepository {
         Ok(())
     }
 
+    /// Update the role of an existing org member
+    pub async fn update_member_role(
+        &self,
+        db: &D1Database,
+        org_id: &str,
+        user_id: &str,
+        new_role: &str,
+    ) -> Result<()> {
+        let stmt =
+            db.prepare("UPDATE org_members SET role = ?3 WHERE org_id = ?1 AND user_id = ?2");
+        stmt.bind(&[org_id.into(), user_id.into(), new_role.into()])?
+            .run()
+            .await?;
+        Ok(())
+    }
+
     /// Count owners of an org (to prevent removing the last owner)
     pub async fn count_owners(&self, db: &D1Database, org_id: &str) -> Result<i64> {
         let stmt = db.prepare(

--- a/src/services/org_service.rs
+++ b/src/services/org_service.rs
@@ -248,6 +248,71 @@ impl OrgService {
         Ok(())
     }
 
+    /// Update a member's role within an org, enforcing role-based permission rules.
+    ///
+    /// Rules:
+    /// - The `new_role` must be 'member' or 'admin' — 'owner' cannot be assigned via this endpoint.
+    /// - Requester must be an owner or admin of the org.
+    /// - A requester cannot change their own role.
+    /// - Admins can only change the role of regular members (not owners or other admins).
+    /// - Owners can change the role of any non-owner member (admin ↔ member).
+    pub async fn update_member_role(
+        &self,
+        db: &D1Database,
+        org_id: &str,
+        requester_id: &str,
+        target_user_id: &str,
+        new_role: &str,
+    ) -> Result<(), AppError> {
+        if new_role != "member" && new_role != "admin" {
+            return Err(AppError::BadRequest(
+                "Role must be 'member' or 'admin'. Ownership transfer is not supported via this endpoint.".to_string(),
+            ));
+        }
+
+        if requester_id == target_user_id {
+            return Err(AppError::Forbidden(
+                "Cannot change your own role".to_string(),
+            ));
+        }
+
+        let repo = OrgRepository::new();
+
+        let requester = repo
+            .get_member(db, org_id, requester_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Organization not found".to_string()))?;
+
+        if requester.role != "owner" && requester.role != "admin" {
+            return Err(AppError::Forbidden(
+                "Only org owners and admins can change member roles".to_string(),
+            ));
+        }
+
+        let target = repo
+            .get_member(db, org_id, target_user_id)
+            .await?
+            .ok_or_else(|| {
+                AppError::NotFound("Member not found in this organization".to_string())
+            })?;
+
+        if target.role == "owner" {
+            return Err(AppError::Forbidden(
+                "Cannot change an owner's role. Transfer ownership is not supported via this endpoint.".to_string(),
+            ));
+        }
+
+        if requester.role == "admin" && target.role == "admin" {
+            return Err(AppError::Forbidden(
+                "Admins cannot change the role of other admins".to_string(),
+            ));
+        }
+
+        repo.update_member_role(db, org_id, target_user_id, new_role)
+            .await?;
+        Ok(())
+    }
+
     // ─── Org Settings ─────────────────────────────────────────────────────────
 
     /// Get org settings (forward_query_params) with membership check.

--- a/tests/orgs_test.rs
+++ b/tests/orgs_test.rs
@@ -827,3 +827,227 @@ async fn test_remove_last_owner_is_rejected() {
 }
 
 // ─── Delete Org ───────────────────────────────────────────────────────────────
+
+// ─── Update Member Role ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_update_member_role_requires_auth() {
+    let client = test_client();
+    let response = client
+        .put(format!(
+            "{}/api/orgs/some-org/members/some-user/role",
+            BASE_URL
+        ))
+        .json(&json!({"role": "admin"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_update_member_role_cannot_set_owner() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let me: Value = client
+        .get(format!("{}/api/auth/me", BASE_URL))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let user_id = me["id"].as_str().unwrap().to_string();
+
+    // Trying to set own role to 'owner' is rejected (would be a self-change anyway, but
+    // if the endpoint hits 'owner' validation first, we should get 400)
+    let response = client
+        .put(format!(
+            "{}/api/orgs/{}/members/{}/role",
+            BASE_URL, org_id, user_id
+        ))
+        .json(&json!({"role": "owner"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_update_member_role_cannot_change_own_role() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let me: Value = client
+        .get(format!("{}/api/auth/me", BASE_URL))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let user_id = me["id"].as_str().unwrap().to_string();
+
+    let response = client
+        .put(format!(
+            "{}/api/orgs/{}/members/{}/role",
+            BASE_URL, org_id, user_id
+        ))
+        .json(&json!({"role": "admin"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_update_member_role_member_not_found() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let response = client
+        .put(format!(
+            "{}/api/orgs/{}/members/00000000-0000-0000-0000-000000000000/role",
+            BASE_URL, org_id
+        ))
+        .json(&json!({"role": "admin"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_update_member_role_missing_role_field_returns_400() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let response = client
+        .put(format!(
+            "{}/api/orgs/{}/members/some-user/role",
+            BASE_URL, org_id
+        ))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ─── Invite with Role ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_invite_with_admin_role_creates_admin_invitation() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let email = format!("admin-invite-{}@example.com", unique_short_code("ai"));
+    let response = client
+        .post(format!("{}/api/orgs/{}/invitations", BASE_URL, org_id))
+        .json(&json!({"email": email, "role": "admin"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(
+        body["invitation"]["role"].as_str().unwrap(),
+        "admin",
+        "Invitation role should be 'admin'"
+    );
+
+    // Clean up
+    let invitation_id = body["invitation"]["id"].as_str().unwrap().to_string();
+    client
+        .delete(format!(
+            "{}/api/orgs/{}/invitations/{}",
+            BASE_URL, org_id, invitation_id
+        ))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_invite_with_member_role_creates_member_invitation() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let email = format!("member-invite-{}@example.com", unique_short_code("mi"));
+    let response = client
+        .post(format!("{}/api/orgs/{}/invitations", BASE_URL, org_id))
+        .json(&json!({"email": email, "role": "member"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(
+        body["invitation"]["role"].as_str().unwrap(),
+        "member",
+        "Invitation role should be 'member'"
+    );
+
+    // Clean up
+    let invitation_id = body["invitation"]["id"].as_str().unwrap().to_string();
+    client
+        .delete(format!(
+            "{}/api/orgs/{}/invitations/{}",
+            BASE_URL, org_id, invitation_id
+        ))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_invite_with_owner_role_is_rejected() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let email = format!("owner-invite-{}@example.com", unique_short_code("oi"));
+    let response = client
+        .post(format!("{}/api/orgs/{}/invitations", BASE_URL, org_id))
+        .json(&json!({"email": email, "role": "owner"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_invite_defaults_to_member_role() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let email = format!("default-role-{}@example.com", unique_short_code("dr"));
+    // Send invite without a 'role' field — should default to 'member'
+    let response = client
+        .post(format!("{}/api/orgs/{}/invitations", BASE_URL, org_id))
+        .json(&json!({"email": email}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(
+        body["invitation"]["role"].as_str().unwrap(),
+        "member",
+        "Invitation should default to 'member' role when role is omitted"
+    );
+
+    // Clean up
+    let invitation_id = body["invitation"]["id"].as_str().unwrap().to_string();
+    client
+        .delete(format!(
+            "{}/api/orgs/{}/invitations/{}",
+            BASE_URL, org_id, invitation_id
+        ))
+        .send()
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
- Add DB migration (0035) enforcing CHECK(role IN ('owner','admin','member'))
- Add PUT /api/orgs/:id/members/:user_id/role endpoint for role updates
- Update invitations to accept optional role field (member|admin, default member)
- Update frontend org page: role badges, role selector per member, invite role picker

Permission rules:
- Owner: can change any non-owner member's role (admin ↔ member)
- Admin: can promote members to admin, cannot touch owners or other admins
- Nobody: can assign 'owner' via this endpoint (ownership transfer not in scope)

Closes #40 