### PR TITLE
feat(admin): reverse user sorting, add mobile pagination, and track last login

### DIFF
--- a/docs/openapi/main.json
+++ b/docs/openapi/main.json
@@ -4458,6 +4458,13 @@
               "string",
               "null"
             ]
+          },
+          "last_login_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
           }
         }
       },

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -11,6 +11,7 @@ export interface User {
   suspended_at: number | null;
   suspension_reason: string | null;
   suspended_by: string | null;
+  last_login_at: number | null;
   billing_account_id?: string | null;
   billing_account_tier?: string | null;
 }

--- a/frontend/src/routes/admin/users/+page.svelte
+++ b/frontend/src/routes/admin/users/+page.svelte
@@ -294,6 +294,16 @@
                 <span class="label">Joined:</span>
                 <span>{formatDate(user.created_at)}</span>
               </div>
+              <div class="card-row">
+                <span class="label">Last Login:</span>
+                <span>
+                  {#if user.last_login_at}
+                    {formatDate(user.last_login_at)}
+                  {:else}
+                    <span class="no-login">Never</span>
+                  {/if}
+                </span>
+              </div>
             </div>
             <div class="card-actions">
               <button
@@ -323,6 +333,18 @@
         {/each}
       </div>
 
+      <!-- Mobile Pagination -->
+      {#if totalPages > 1}
+        <div class="mobile-pagination">
+          <Pagination
+            {currentPage}
+            {totalPages}
+            onPageChange={handlePageChange}
+            {loading}
+          />
+        </div>
+      {/if}
+
       <!-- Desktop Table View -->
       <div class="users-table">
         <table>
@@ -336,6 +358,7 @@
               <th>Billing Account</th>
               <th>Tier</th>
               <th>Joined</th>
+              <th>Last Login</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -407,6 +430,13 @@
                   {/if}
                 </td>
                 <td class="date">{formatDate(user.created_at)}</td>
+                <td class="date">
+                  {#if user.last_login_at}
+                    {formatDate(user.last_login_at)}
+                  {:else}
+                    <span class="no-login">Never</span>
+                  {/if}
+                </td>
                 <td>
                   {#if currentUser && user.id === currentUser.id}
                     <span class="no-actions">Cannot edit self</span>
@@ -1044,6 +1074,12 @@
     font-size: 0.875rem;
   }
 
+  .no-login {
+    color: #9ca3af;
+    font-size: 0.875rem;
+    font-style: italic;
+  }
+
   .no-actions {
     color: #9ca3af;
     font-size: 0.875rem;
@@ -1258,6 +1294,14 @@
     cursor: not-allowed;
   }
 
+  /* Mobile Pagination */
+  .mobile-pagination {
+    display: none;
+    padding: 1rem;
+    border-top: 1px solid #e2e8f0;
+    background: #f8fafc;
+  }
+
   /* Responsive */
   @media (max-width: 768px) {
     .mobile-cards {
@@ -1266,6 +1310,10 @@
 
     .users-table {
       display: none;
+    }
+
+    .mobile-pagination {
+      display: block;
     }
 
     .users-container {

--- a/migrations/0037_last_login.sql
+++ b/migrations/0037_last_login.sql
@@ -1,0 +1,4 @@
+-- Add last_login_at column to users table
+-- This will track the most recent login timestamp for each user
+
+ALTER TABLE users ADD COLUMN last_login_at INTEGER;

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -316,6 +316,9 @@ async fn create_or_get_user(
             .create_or_update(db, create_data, &user.org_id)
             .await?;
 
+        // Update last login timestamp
+        user_repo.update_last_login(db, &updated_user.id).await?;
+
         let org_repo = OrgRepository::new();
         let org = org_repo
             .get_by_id(db, &user.org_id)
@@ -370,6 +373,9 @@ async fn create_or_get_user(
         let updated_user = user_repo
             .create_or_update(db, create_data, &user.org_id)
             .await?;
+
+        // Update last login timestamp
+        user_repo.update_last_login(db, &updated_user.id).await?;
 
         let org_repo = OrgRepository::new();
         let org = org_repo
@@ -426,6 +432,9 @@ async fn create_or_get_user(
     };
     let user = user_repo.create_or_update(db, create_data, &org.id).await?;
 
+    // Update last login timestamp
+    user_repo.update_last_login(db, &user.id).await?;
+
     // Add the user as an organization member with owner role
     org_repo.add_member(db, &org.id, &user.id, "owner").await?;
 
@@ -458,6 +467,7 @@ mod tests {
             suspended_at: None,
             suspension_reason: None,
             suspended_by: None,
+            last_login_at: None,
         }
     }
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -27,6 +27,8 @@ pub struct User {
     pub suspension_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suspended_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_login_at: Option<i64>,
 }
 
 impl User {

--- a/src/repositories/user_repository.rs
+++ b/src/repositories/user_repository.rs
@@ -23,6 +23,7 @@ pub struct UserWithBillingInfo {
     pub suspended_at: Option<i64>,
     pub suspension_reason: Option<String>,
     pub suspended_by: Option<String>,
+    pub last_login_at: Option<i64>,
     pub billing_account_id: Option<String>,
     pub billing_account_tier: Option<String>,
 }
@@ -49,7 +50,7 @@ impl UserRepository {
         // Try to find existing user by OAuth provider and ID
         let stmt = db.prepare(
             "SELECT id, email, name, avatar_url, oauth_provider, oauth_id, org_id, role, created_at,
-                    suspended_at, suspension_reason, suspended_by
+                    suspended_at, suspension_reason, suspended_by, last_login_at
              FROM users
              WHERE oauth_provider = ?1 AND oauth_id = ?2",
         );
@@ -93,6 +94,7 @@ impl UserRepository {
                 suspended_at: user.suspended_at,
                 suspension_reason: user.suspension_reason,
                 suspended_by: user.suspended_by,
+                last_login_at: user.last_login_at,
             })
         } else {
             // Determine role: first user on the instance gets admin, all others get member
@@ -133,6 +135,7 @@ impl UserRepository {
                 suspended_at: None,
                 suspension_reason: None,
                 suspended_by: None,
+                last_login_at: None,
             })
         }
     }
@@ -141,7 +144,7 @@ impl UserRepository {
     pub async fn get_user_by_id(&self, db: &D1Database, user_id: &str) -> Result<Option<User>> {
         let stmt = db.prepare(
             "SELECT id, email, name, avatar_url, oauth_provider, oauth_id, org_id, role, created_at,
-                    suspended_at, suspension_reason, suspended_by
+                    suspended_at, suspension_reason, suspended_by, last_login_at
              FROM users
              WHERE id = ?1",
         );
@@ -152,7 +155,7 @@ impl UserRepository {
     pub async fn get_by_email(&self, db: &D1Database, email: &str) -> Result<Option<User>> {
         let stmt = db.prepare(
             "SELECT id, email, name, avatar_url, oauth_provider, oauth_id, org_id, role, created_at,
-                    suspended_at, suspension_reason, suspended_by
+                    suspended_at, suspension_reason, suspended_by, last_login_at
              FROM users
              WHERE email = ?1",
         );
@@ -169,12 +172,12 @@ impl UserRepository {
         let rows = db
             .prepare(
                 "SELECT u.id, u.email, u.name, u.avatar_url, u.oauth_provider, u.oauth_id,
-                        u.org_id, u.role, u.created_at, u.suspended_at, u.suspension_reason, u.suspended_by,
+                        u.org_id, u.role, u.created_at, u.suspended_at, u.suspension_reason, u.suspended_by, u.last_login_at,
                         o.billing_account_id, ba.tier as billing_account_tier
                  FROM users u
                  LEFT JOIN organizations o ON u.org_id = o.id
                  LEFT JOIN billing_accounts ba ON o.billing_account_id = ba.id
-                 ORDER BY u.created_at ASC
+                 ORDER BY u.created_at DESC
                  LIMIT ?1 OFFSET ?2",
             )
             .bind(&[(limit as f64).into(), (offset as f64).into()])?
@@ -198,6 +201,7 @@ impl UserRepository {
                     suspended_at: row["suspended_at"].as_f64().map(|v| v as i64),
                     suspension_reason: row["suspension_reason"].as_str().map(|s| s.to_string()),
                     suspended_by: row["suspended_by"].as_str().map(|s| s.to_string()),
+                    last_login_at: row["last_login_at"].as_f64().map(|v| v as i64),
                     billing_account_id: row["billing_account_id"].as_str().map(|s| s.to_string()),
                     billing_account_tier: row["billing_account_tier"]
                         .as_str()
@@ -399,6 +403,16 @@ impl UserRepository {
             .and_then(|m| m.changes)
             .map(|c| c as i64)
             .unwrap_or(0))
+    }
+
+    /// Update the last login timestamp for a user.
+    pub async fn update_last_login(&self, db: &D1Database, user_id: &str) -> Result<()> {
+        let now = now_timestamp();
+        let stmt = db.prepare("UPDATE users SET last_login_at = ?1 WHERE id = ?2");
+        stmt.bind(&[(now as f64).into(), user_id.into()])?
+            .run()
+            .await?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- Reverse chronological user sorting in admin console (newest first)
- Add mobile pagination navigation to user list page
- Implement last login tracking with new last_login_at column
- Update OAuth callbacks to record login timestamps
- Add "Last Login" column to desktop and mobile user views
- Include last login info in API responses and TypeScript types

Closes #385 