### PR TITLE
fix: security headers silently dropped on ASSETS-binding responses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod scheduled;
 mod services;
 pub mod utils;
 
-use middleware::{add_cors_headers, add_security_headers};
+use middleware::{add_cors_headers, add_security_headers, rebuild_asset_response};
 
 #[event(fetch)]
 async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
@@ -58,7 +58,8 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
         let asset_url = url.to_string();
         match assets.fetch(asset_url, None).await {
             Ok(asset_response) if asset_response.status_code() < 400 => {
-                let response_with_headers = add_security_headers(asset_response, is_https);
+                let rebuilt = rebuild_asset_response(asset_response, path).await?;
+                let response_with_headers = add_security_headers(rebuilt, is_https);
                 return Ok(add_cors_headers(response_with_headers, origin, &env));
             }
             _ => {
@@ -94,7 +95,8 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
         if let Ok(fallback_response) = assets.fetch(fallback_url, None).await
             && fallback_response.status_code() < 400
         {
-            let response_with_headers = add_security_headers(fallback_response, is_https);
+            let rebuilt = rebuild_asset_response(fallback_response, path).await?;
+            let response_with_headers = add_security_headers(rebuilt, is_https);
             return Ok(add_cors_headers(response_with_headers, origin, &env));
         }
     }

--- a/src/middleware/cors.rs
+++ b/src/middleware/cors.rs
@@ -1,5 +1,5 @@
 /// CORS and security header middleware
-use worker::{Env, Response};
+use worker::{Env, Headers, Response, Result};
 
 /// Check if an origin is allowed for CORS
 pub fn is_allowed_origin(origin: &str, env: &Env) -> bool {
@@ -69,10 +69,10 @@ pub fn add_security_headers(mut response: Response, is_https: bool) -> Response 
     // - upgrade-insecure-requests: Automatically upgrade HTTP to HTTPS
     let csp = if is_https {
         "default-src 'self'; \
-         script-src 'self'; \
+         script-src 'self' 'unsafe-inline'; \
          style-src 'self' 'unsafe-inline'; \
          img-src 'self' data: https:; \
-         font-src 'self'; \
+         font-src 'self' data:; \
          connect-src 'self'; \
          frame-ancestors 'none'; \
          base-uri 'self'; \
@@ -81,10 +81,10 @@ pub fn add_security_headers(mut response: Response, is_https: bool) -> Response 
     } else {
         // Development mode (no upgrade-insecure-requests for localhost)
         "default-src 'self'; \
-         script-src 'self'; \
+         script-src 'self' 'unsafe-inline'; \
          style-src 'self' 'unsafe-inline'; \
          img-src 'self' data: https:; \
-         font-src 'self'; \
+         font-src 'self' data:; \
          connect-src 'self'; \
          frame-ancestors 'none'; \
          base-uri 'self'; \
@@ -119,6 +119,154 @@ pub fn add_security_headers(mut response: Response, is_https: bool) -> Response 
     );
 
     response
+}
+
+/// Compute the filtered and augmented header list for a rebuilt asset response.
+///
+/// Pure function (no wasm I/O) so it can be unit-tested on native targets.
+/// Rules applied to the incoming `(name, value)` pairs:
+/// - Drop `content-encoding` — Cloudflare re-applies compression on egress.
+/// - Drop `content-length` — body length changes after we strip encoding.
+/// - For `/_app/immutable/*` paths, drop `cache-control` from the source and
+///   inject a long-lived immutable directive instead.
+pub fn build_asset_headers(source: &[(String, String)], path: &str) -> Vec<(String, String)> {
+    let is_immutable = path.starts_with("/_app/immutable/");
+    let mut out: Vec<(String, String)> = source
+        .iter()
+        .filter(|(k, _)| {
+            let lk = k.to_lowercase();
+            if lk == "content-encoding" || lk == "content-length" {
+                return false;
+            }
+            if lk == "cache-control" && is_immutable {
+                return false;
+            }
+            true
+        })
+        .cloned()
+        .collect();
+    if is_immutable {
+        out.push((
+            "Cache-Control".to_string(),
+            "public, max-age=31536000, immutable".to_string(),
+        ));
+    }
+    out
+}
+
+/// Rebuild an ASSETS-binding response with a fresh mutable Headers object
+///
+/// Responses from `Fetcher::fetch()` have an immutable Headers guard per the Fetch API spec,
+/// so `headers_mut().set()` is a silent no-op on those responses. This function copies all
+/// headers into a new mutable Headers, rebuilds the response body, and — for content-hashed
+/// assets under `/_app/immutable/` — replaces the cache-control with a long immutable TTL.
+/// `content-encoding` and `content-length` are dropped so Cloudflare re-applies correct
+/// encoding on egress after we modify the headers.
+pub async fn rebuild_asset_response(mut resp: Response, path: &str) -> Result<Response> {
+    let status = resp.status_code();
+    let source: Vec<(String, String)> = resp.headers().entries().collect();
+    let headers = Headers::new();
+    for (k, v) in build_asset_headers(&source, path) {
+        let _ = headers.set(&k, &v);
+    }
+    let bytes = resp.bytes().await.unwrap_or_default();
+    Ok(Response::from_bytes(bytes)?
+        .with_headers(headers)
+        .with_status(status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(k: &str, v: &str) -> (String, String) {
+        (k.to_string(), v.to_string())
+    }
+
+    fn find<'a>(headers: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        headers
+            .iter()
+            .find(|(k, _)| k.to_lowercase() == key.to_lowercase())
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn test_build_asset_headers_drops_content_encoding() {
+        let source = vec![
+            h("content-type", "text/html"),
+            h("content-encoding", "br"),
+            h("content-length", "1234"),
+        ];
+        let out = build_asset_headers(&source, "/index.html");
+        assert!(find(&out, "content-encoding").is_none());
+        assert!(find(&out, "content-length").is_none());
+        assert_eq!(find(&out, "content-type"), Some("text/html"));
+    }
+
+    #[test]
+    fn test_build_asset_headers_immutable_path_sets_long_cache() {
+        let source = vec![
+            h("content-type", "application/javascript"),
+            h("cache-control", "public, max-age=0, must-revalidate"),
+        ];
+        let out = build_asset_headers(&source, "/_app/immutable/chunks/foo.js");
+        assert_eq!(
+            find(&out, "cache-control"),
+            Some("public, max-age=31536000, immutable")
+        );
+    }
+
+    #[test]
+    fn test_build_asset_headers_non_immutable_path_keeps_original_cache() {
+        let source = vec![
+            h("content-type", "text/html"),
+            h("cache-control", "public, max-age=0, must-revalidate"),
+        ];
+        let out = build_asset_headers(&source, "/fallback.html");
+        assert_eq!(
+            find(&out, "cache-control"),
+            Some("public, max-age=0, must-revalidate")
+        );
+    }
+
+    #[test]
+    fn test_build_asset_headers_immutable_only_one_cache_control() {
+        let source = vec![h("cache-control", "public, max-age=0, must-revalidate")];
+        let out = build_asset_headers(&source, "/_app/immutable/entry/start.js");
+        let cc_values: Vec<&str> = out
+            .iter()
+            .filter(|(k, _)| k.to_lowercase() == "cache-control")
+            .map(|(_, v)| v.as_str())
+            .collect();
+        assert_eq!(cc_values.len(), 1);
+        assert_eq!(cc_values[0], "public, max-age=31536000, immutable");
+    }
+
+    #[test]
+    fn test_build_asset_headers_preserves_other_headers() {
+        let source = vec![
+            h("content-type", "text/css"),
+            h("etag", "\"abc123\""),
+            h("vary", "Accept-Encoding"),
+        ];
+        let out = build_asset_headers(&source, "/_app/immutable/assets/style.css");
+        assert_eq!(find(&out, "content-type"), Some("text/css"));
+        assert_eq!(find(&out, "etag"), Some("\"abc123\""));
+        assert_eq!(find(&out, "vary"), Some("Accept-Encoding"));
+    }
+
+    #[test]
+    fn test_build_asset_headers_case_insensitive_drops() {
+        let source = vec![
+            h("Content-Encoding", "gzip"),
+            h("Content-Length", "999"),
+            h("content-type", "image/png"),
+        ];
+        let out = build_asset_headers(&source, "/favicon.ico");
+        assert!(find(&out, "content-encoding").is_none());
+        assert!(find(&out, "content-length").is_none());
+        assert_eq!(find(&out, "content-type"), Some("image/png"));
+    }
 }
 
 /// Add CORS headers to a response based on the request origin

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,5 +1,5 @@
 pub mod cors;
 pub mod rate_limit;
 
-pub use cors::{add_cors_headers, add_security_headers};
+pub use cors::{add_cors_headers, add_security_headers, rebuild_asset_response};
 pub use rate_limit::{RateLimitConfig, RateLimiter, is_kv_rate_limiting_enabled};


### PR DESCRIPTION
Responses from `Fetcher::fetch()` carry an immutable Headers guard per the Fetch API spec, making all `headers_mut().set()` calls silent no-ops on the ASSETS binding path. Every HTML page and static asset served on the frontend domain was missing CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy and X-Content-Type-Options. Verified against production.

Fix: introduce `rebuild_asset_response()` which copies source headers into a fresh mutable Headers object and reconstructs the response from raw bytes before security headers are applied. `content-encoding` and `content-length` are dropped so Cloudflare re-applies correct compression on egress. Assets under `/_app/immutable/` get `cache-control: public, max-age=31536000, immutable` instead of the broken `max-age=0, must-revalidate`.

Also fixes CSP `script-src` to include `'unsafe-inline'` (required for SvelteKit's inline bootstrap) and extends `font-src` with `data:`.

Closes #388 