### PR TITLE
fix(ci): remove [build] section from wrangler.toml to prevent recursive builds

### DIFF
--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -15,9 +15,6 @@ head_sampling_rate = 1
 enabled = true
 head_sampling_rate = 0.1
 
-[build]
-command = "cargo install -q worker-build && worker-build --release"
-
 # Cron Triggers for scheduled tasks
 # Format: array of cron expressions (Cloudflare doesn't support named triggers)
 # - "0 0 * * *" = midnight UTC daily (subscription downgrade)


### PR DESCRIPTION
The [build] command in wrangler.toml was causing worker-build to recursively invoke itself during CI, leading to "Cleaning up..." errors before tests could start.

The CI workflow already runs `worker-build --release` directly, so the custom build command in wrangler.toml is redundant and was creating a build loop when worker-build internally invoked wrangler.

This should fix the flaky integration test execution on GitHub Actions.