### PR TITLE
fix(security): include API domain in CSP connect-src directive

### DIFF
--- a/docs/openapi/main.json
+++ b/docs/openapi/main.json
@@ -11,7 +11,7 @@
       "name": "AGPL-3.0",
       "url": "https://www.gnu.org/licenses/agpl-3.0.html"
     },
-    "version": "0.10.0"
+    "version": "0.11.0"
   },
   "servers": [
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
         match assets.fetch(asset_url, None).await {
             Ok(asset_response) if asset_response.status_code() < 400 => {
                 let rebuilt = rebuild_asset_response(asset_response, path).await?;
-                let response_with_headers = add_security_headers(rebuilt, is_https);
+                let response_with_headers = add_security_headers(rebuilt, is_https, &env);
                 return Ok(add_cors_headers(response_with_headers, origin, &env));
             }
             _ => {
@@ -96,12 +96,12 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
             && fallback_response.status_code() < 400
         {
             let rebuilt = rebuild_asset_response(fallback_response, path).await?;
-            let response_with_headers = add_security_headers(rebuilt, is_https);
+            let response_with_headers = add_security_headers(rebuilt, is_https, &env);
             return Ok(add_cors_headers(response_with_headers, origin, &env));
         }
     }
 
     // Add security headers and CORS headers to all responses
-    let response = add_security_headers(response, is_https);
+    let response = add_security_headers(response, is_https, &env);
     Ok(add_cors_headers(response, origin, &env))
 }

--- a/src/middleware/cors.rs
+++ b/src/middleware/cors.rs
@@ -53,8 +53,16 @@ pub fn is_allowed_origin(origin: &str, env: &Env) -> bool {
 /// - Strict-Transport-Security: Forces HTTPS (production only)
 /// - Referrer-Policy: Controls referrer information leakage
 /// - Permissions-Policy: Restricts access to browser features
-pub fn add_security_headers(mut response: Response, is_https: bool) -> Response {
+pub fn add_security_headers(mut response: Response, is_https: bool, env: &Env) -> Response {
     let headers = response.headers_mut();
+
+    // Get API domain for connect-src - needed when frontend and API are on different domains
+    let api_domain = env.var("DOMAIN").map(|d| d.to_string()).unwrap_or_default();
+    let connect_src = if api_domain.is_empty() {
+        "connect-src 'self';".to_string()
+    } else {
+        format!("connect-src 'self' https://{};", api_domain)
+    };
 
     // Content Security Policy - Defense in depth against XSS
     // - default-src 'self': Only load resources from same origin by default
@@ -62,33 +70,39 @@ pub fn add_security_headers(mut response: Response, is_https: bool) -> Response 
     // - style-src 'self' 'unsafe-inline': Allow same-origin styles + inline (needed for SvelteKit)
     // - img-src 'self' data: https:: Allow images from same origin, data URIs, and HTTPS
     // - font-src 'self': Only load fonts from same origin
-    // - connect-src 'self': Only allow API calls to same origin
+    // - connect-src 'self' [api_domain]: Allow API calls to same origin and configured API domain
     // - frame-ancestors 'none': Prevent embedding in iframes (redundant with X-Frame-Options)
     // - base-uri 'self': Prevent base tag injection
     // - form-action 'self': Restrict form submissions to same origin
     // - upgrade-insecure-requests: Automatically upgrade HTTP to HTTPS
     let csp = if is_https {
-        "default-src 'self'; \
+        &format!(
+            "default-src 'self'; \
          script-src 'self' 'unsafe-inline'; \
          style-src 'self' 'unsafe-inline'; \
          img-src 'self' data: https:; \
          font-src 'self' data:; \
-         connect-src 'self'; \
+         {} \
          frame-ancestors 'none'; \
          base-uri 'self'; \
          form-action 'self'; \
-         upgrade-insecure-requests"
+         upgrade-insecure-requests",
+            connect_src
+        )
     } else {
         // Development mode (no upgrade-insecure-requests for localhost)
-        "default-src 'self'; \
+        &format!(
+            "default-src 'self'; \
          script-src 'self' 'unsafe-inline'; \
          style-src 'self' 'unsafe-inline'; \
          img-src 'self' data: https:; \
          font-src 'self' data:; \
-         connect-src 'self'; \
+         {} \
          frame-ancestors 'none'; \
          base-uri 'self'; \
-         form-action 'self'"
+         form-action 'self'",
+            connect_src
+        )
     };
     let _ = headers.set("Content-Security-Policy", csp);
 


### PR DESCRIPTION
The CSP header had `connect-src 'self'` which only allowed same-origin requests. In production, the frontend (rushomon.cc) makes API calls to a different domain (api.rushomon.cc), causing CSP violations.

Fixed by reading the DOMAIN env var and including it in the connect-src directive: `connect-src 'self' https://<api_domain>;`

All pre-commit checks pass (260 unit tests, clippy, formatting).