### PR TITLE
Switch to mshick/add-pr-comment for Node 24 compatibility

### DIFF
--- a/.github/workflows/cleanup-ephemeral.yml
+++ b/.github/workflows/cleanup-ephemeral.yml
@@ -404,9 +404,8 @@ jobs:
 
       - name: Post Cleanup Notification
         if: always()
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0
         with:
-          pr-number: ${{ steps.pr_number.outputs.pr_number }}
           message: |
             ${{ steps.check_deployment.outputs.should_cleanup == 'true' && '🧹 **Ephemeral Environment Cleaned Up**' || '⏭️ **Ephemeral Environment Cleanup Skipped**' }}
 

--- a/.github/workflows/deploy-ephemeral.yml
+++ b/.github/workflows/deploy-ephemeral.yml
@@ -724,9 +724,8 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0
         with:
-          pr-number: ${{ steps.pr_number.outputs.pr_number }}
           message: |
             🚀 **Ephemeral Environment Deployed (Unified Worker)**
 
@@ -835,9 +834,8 @@ jobs:
           echo "✅ Docs deployed to https://rushomon-docs-pr-$PR_NUMBER.$WORKERS_DOMAIN"
 
       - name: Comment on PR with docs URL
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0
         with:
-          pr-number: ${{ steps.pr_number.outputs.pr_number }}
           message: |
             📚 **Docs Preview Deployed**
 
@@ -862,9 +860,8 @@ jobs:
 
     steps:
       - name: Comment why deployment was skipped
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0
         with:
-          pr-number: ${{ github.event.pull_request.number }}
           message: |
             ⏭️ **Ephemeral Environment Deployment Skipped**
 


### PR DESCRIPTION
* Replace unmaintained thollander/actions-comment-pull-request with actively maintained mshick/add-pr-comment which uses Node 24 runtime.
* Updates 4 occurrences across deploy-ephemeral.yml and cleanup-ephemeral.yml.

Closes #187 