### PR TITLE
fix: use PAT with Administration:write to delete GitHub environments

### DIFF
--- a/.github/workflows/cleanup-ephemeral.yml
+++ b/.github/workflows/cleanup-ephemeral.yml
@@ -381,24 +381,28 @@ jobs:
       - name: Delete GitHub Environment
         if: always() && steps.check_deployment.outputs.should_cleanup == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
         run: |
           PR_NUMBER="${{ steps.pr_number.outputs.pr_number }}"
           ENVIRONMENT="ephemeral-pr-$PR_NUMBER"
 
           echo "Deleting GitHub environment: $ENVIRONMENT"
 
-          # Delete the environment
-          DELETE_RESPONSE=$(gh api \
-            --method DELETE \
-            repos/${{ github.repository }}/environments/$ENVIRONMENT 2>&1)
-          DELETE_EXIT_CODE=$?
+          # Delete the environment using a PAT with Administration:write permission
+          # (GITHUB_TOKEN cannot delete environments - requires repo-level admin access)
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_ADMIN_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/environments/$ENVIRONMENT")
 
-          if [ $DELETE_EXIT_CODE -eq 0 ]; then
+          if [ "$HTTP_CODE" = "204" ]; then
             echo "✅ Successfully deleted GitHub environment: $ENVIRONMENT"
+          elif [ "$HTTP_CODE" = "404" ]; then
+            echo "⚠️  GitHub environment not found: $ENVIRONMENT (may have already been deleted)"
           else
-            echo "⚠️  Failed to delete GitHub environment: $ENVIRONMENT"
-            echo "Response: $DELETE_RESPONSE"
+            echo "⚠️  Failed to delete GitHub environment: $ENVIRONMENT (HTTP $HTTP_CODE)"
             # Continue anyway - environment may not exist or may have been deleted already
           fi
 


### PR DESCRIPTION
GITHUB_TOKEN cannot delete GitHub environments regardless of the `permissions` block in the workflow YAML — the API endpoint `DELETE /repos/{owner}/{repo}/environments/{environment_name}` requires "Repository Administration: write" which is only available via a fine-grained PAT or GitHub App token.

Replace the failing `gh api --method DELETE` call (which used github.token) with a curl DELETE using the new GH_ADMIN_TOKEN secret (a fine-grained PAT scoped to piffio/rushomon with Administration:write).

Also improves error handling: distinguishes 204 (success), 404 (already deleted), and other failure codes.

Closes #410 