### PR TITLE
fix(ci): clippy lints and worker-build 0.8.5 regression

### DIFF
--- a/.github/workflows/deploy-ephemeral.yml
+++ b/.github/workflows/deploy-ephemeral.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Install wrangler and worker-build
         run: |
           npm install -g wrangler
-          cargo install -q worker-build
+          cargo install -q worker-build --version 0.8.4
 
       - name: Build Worker
         run: worker-build --release
@@ -241,7 +241,7 @@ jobs:
           head_sampling_rate = 0.1
 
           [build]
-          command = "cargo install -q worker-build && worker-build --release"
+          command = "cargo install -q worker-build --version 0.8.4 && worker-build --release"
 
           # Cron Triggers for scheduled tasks
           # Format: array of cron expressions (Cloudflare doesn't support named triggers)

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Install wrangler and worker-build
         run: |
           npm install -g wrangler
-          cargo install -q worker-build
+          cargo install -q worker-build --version 0.8.4
 
       - name: Build Worker
         run: worker-build --release

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -249,7 +249,7 @@ jobs:
         run: npm install -g wrangler
 
       - name: Install worker-build
-        run: cargo install worker-build
+        run: cargo install worker-build --version 0.8.4
 
       - name: Build backend
         run: worker-build --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install wrangler and worker-build
         run: |
           npm install -g wrangler
-          cargo install -q worker-build
+          cargo install -q worker-build --version 0.8.4
 
       - name: Create frontend build stub
         run: |

--- a/src/api/title_fetch.rs
+++ b/src/api/title_fetch.rs
@@ -89,10 +89,7 @@ fn extract_title(html: &str) -> Option<String> {
 
     if let Some(start) = html_lower.find("<title") {
         // Find the end of the opening title tag
-        let tag_end = match html[start..].find('>') {
-            Some(pos) => start + pos + 1,
-            None => return None,
-        };
+        let tag_end = start + html[start..].find('>')? + 1;
 
         // Find the closing title tag
         if let Some(end) = html_lower[tag_end..].find("</title>") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ async fn main(req: Request, env: Env, worker_ctx: Context) -> Result<Response> {
         && !path.starts_with("/api/")
         && let Ok(assets) = env.get_binding::<worker::Fetcher>("ASSETS")
     {
-        let fallback_url = format!("{}://{}/fallback.html", url.scheme(), &request_authority);
+        let fallback_url = format!("{}://{}/fallback.html", url.scheme(), request_authority);
         if let Ok(fallback_response) = assets.fetch(fallback_url, None).await
             && fallback_response.status_code() < 400
         {


### PR DESCRIPTION
CI has been red on every PR since mid-June for two independent reasons, this fixes both.

**1. Integration Tests / deploys: worker-build 0.8.5 regression.** worker-build 0.8.5 (released June 12) fails against this codebase during the wasm-bindgen step:

```
error: failed to generate catch wrappers
Caused by: externref table required for catch wrappers
```

All workflows install worker-build unpinned (`cargo install -q worker-build`), so the Integration Tests job, and the deploy workflows, pick up 0.8.5 and fail at Build Worker. It appears 0.8.5 forces wasm-bindgen's abort-handler pass without enabling reference-types. This PR pins all five install sites to 0.8.4, the last working release (verified locally: builds and passes the full integration suite). The pin can be dropped once a fixed worker-build ships.

**2. Clippy: new lints on current stable.** `cargo clippy -- -D warnings` on current stable Rust fails on two pre-existing patterns (`clippy::question_mark` in `title_fetch.rs`, `clippy::useless_borrows_in_formatting` in `lib.rs`).

With both, this PR's own checks should come up green.