### PR TITLE
ci: harden deploy workflows for minimal self-hosted configurations

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -72,9 +72,14 @@ jobs:
           # Format: array of cron expressions (Cloudflare doesn't support named triggers)
           # - "0 0 * * *" = midnight UTC daily (subscription downgrade)
           # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
-          # - "*/15 * * * *" = every 15 min (custom domain status polling)
+          # - "*/15 * * * *" = every 15 min (custom domain status polling) — only
+          #   registered when Cloudflare-for-SaaS is configured (CF_SAAS_API_TOKEN)
+          # - "0 8 2 * *" = monthly stats emails — only registered when Mailgun is
+          #   configured (MAILGUN_DOMAIN)
+          # Conditional registration keeps unconfigured features from consuming the
+          # free plan's cron quota (5 triggers per account) with no-op jobs.
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *", "*/15 * * * *", "0 8 2 * *"]
+          crons = ${{ format('["0 0 * * *", "0 4 * * *"{0}{1}]', secrets.CF_SAAS_API_TOKEN != '' && ', "*/15 * * * *"' || '', secrets.MAILGUN_DOMAIN != '' && ', "0 8 2 * *"' || '') }}
 
           [[d1_databases]]
           binding = "rushomon"
@@ -230,9 +235,14 @@ jobs:
           # Format: array of cron expressions (Cloudflare doesn't support named triggers)
           # - "0 0 * * *" = midnight UTC daily (subscription downgrade)
           # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
-          # - "*/15 * * * *" = every 15 min (custom domain status polling)
+          # - "*/15 * * * *" = every 15 min (custom domain status polling) — only
+          #   registered when Cloudflare-for-SaaS is configured (CF_SAAS_API_TOKEN)
+          # - "0 8 2 * *" = monthly stats emails — only registered when Mailgun is
+          #   configured (MAILGUN_DOMAIN)
+          # Conditional registration keeps unconfigured features from consuming the
+          # free plan's cron quota (5 triggers per account) with no-op jobs.
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *", "*/15 * * * *", "0 8 2 * *"]
+          crons = ${{ format('["0 0 * * *", "0 4 * * *"{0}{1}]', secrets.CF_SAAS_API_TOKEN != '' && ', "*/15 * * * *"' || '', secrets.MAILGUN_DOMAIN != '' && ', "0 8 2 * *"' || '') }}
 
           [[d1_databases]]
           binding = "rushomon"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -188,7 +188,8 @@ jobs:
           PUBLIC_VITE_API_BASE_URL: https://${{ secrets.API_DOMAIN }}
           PUBLIC_VITE_SHORT_LINK_BASE_URL: https://${{ secrets.REDIRECT_DOMAIN }}
           PUBLIC_VITE_SITE_URL: https://${{ secrets.WEB_DOMAIN }}
-          PUBLIC_VITE_DOCS_URL: https://${{ secrets.DOCS_DOMAIN }}
+          # Empty when DOCS_DOMAIN is unset so the frontend's built-in fallback is used
+          PUBLIC_VITE_DOCS_URL: ${{ secrets.DOCS_DOMAIN != '' && format('https://{0}', secrets.DOCS_DOMAIN) || '' }}
         run: |
           echo "🔨 Building frontend for unified Worker deployment"
           echo "   API Base URL: https://${{ secrets.API_DOMAIN }}"
@@ -607,6 +608,9 @@ jobs:
           echo ""
           echo "📚 Test 6: Docs Site Homepage"
           echo "-----------------------------"
+          if [ -z "${{ secrets.DOCS_DOMAIN }}" ]; then
+            echo "⚠️  DOCS_DOMAIN not configured — skipping docs site test"
+          else
           DOCS_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
             -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" \
             -H "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8" \
@@ -618,6 +622,7 @@ jobs:
             echo "   This is expected on the free Cloudflare plan with Bot Fight Mode enabled."
           else
             echo "⚠️  Docs homepage returned HTTP $DOCS_STATUS (custom domain may not be configured yet)"
+          fi
           fi
 
           echo ""

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -637,8 +637,9 @@ jobs:
           echo "🛡️  Restoring Bot Fight Mode to original state..."
 
           if [ -z "$ORIGINAL_STATE" ] || [ "$ORIGINAL_STATE" = "unknown" ]; then
-            echo "⚠️  Original state unknown, defaulting to enabled (fight_mode: true)"
-            ORIGINAL_STATE="true"
+            echo "⚠️  Original Bot Fight Mode state unknown — leaving zone settings untouched"
+            echo "   (The zone either has Bot Fight Mode unconfigured or the state could not be read.)"
+            exit 0
           fi
 
           echo "Restoring to: fight_mode=$ORIGINAL_STATE"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -75,7 +75,8 @@ jobs:
           # - "0 0 * * *" = midnight UTC daily (subscription downgrade)
           # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *", "0 8 2 * *"]
+          # The monthly stats cron is only registered when Mailgun is configured
+          crons = ${{ format('["0 0 * * *", "0 4 * * *"{0}]', secrets.MAILGUN_DOMAIN != '' && ', "0 8 2 * *"' || '') }}
 
           [[d1_databases]]
           binding = "rushomon"
@@ -177,7 +178,8 @@ jobs:
           # - "0 0 * * *" = midnight UTC daily (subscription downgrade)
           # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
           [triggers]
-          crons = ["0 0 * * *", "0 4 * * *", "0 8 2 * *"]
+          # The monthly stats cron is only registered when Mailgun is configured
+          crons = ${{ format('["0 0 * * *", "0 4 * * *"{0}]', secrets.MAILGUN_DOMAIN != '' && ', "0 8 2 * *"' || '') }}
 
           [[d1_databases]]
           binding = "rushomon"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -266,7 +266,8 @@ jobs:
           PUBLIC_VITE_API_BASE_URL: https://${{ secrets.WEB_DOMAIN }}
           PUBLIC_VITE_SHORT_LINK_BASE_URL: https://${{ secrets.REDIRECT_DOMAIN }}
           PUBLIC_VITE_SITE_URL: https://${{ secrets.WEB_DOMAIN }}
-          PUBLIC_VITE_DOCS_URL: https://${{ secrets.DOCS_DOMAIN }}
+          # Empty when DOCS_DOMAIN is unset so the frontend's built-in fallback is used
+          PUBLIC_VITE_DOCS_URL: ${{ secrets.DOCS_DOMAIN != '' && format('https://{0}', secrets.DOCS_DOMAIN) || '' }}
         run: npm run build
 
       - name: Apply database migrations

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -21,6 +21,7 @@ head_sampling_rate = 0.1
 # - "0 4 * * *" = 4 AM UTC daily (webhook cleanup)
 # - "0 8 2 * *" = 8 AM UTC on day 2 of each month (monthly stats email)
 [triggers]
+# Note: the Workers free plan allows 5 cron triggers per account
 crons = ["0 0 * * *", "0 4 * * *", "0 8 2 * *"]
 
 # KV Namespace for URL mappings


### PR DESCRIPTION
Follow-up to the worker-build pin PR #438. While bringing three self-hosted instances up to current main, the deploy workflows failed on configurations that any minimal self-hosted setup is likely to share. Each fix keeps current behaviour for fully-configured deployments (your SaaS setup should see no change).

**1. Bot Fight Mode restore tried to enable a feature that was never on.**

When the pre-test state read returns nothing (zone has Bot Fight Mode unconfigured, or no token), the restore step defaulted to `fight_mode=true` and fails with `cannot enable Fight_Mode while EnableJS is disabled`. It now leaves the zone untouched when the original state is unknown.

**2. An unset `DOCS_DOMAIN` breaks the build and the smoke tests.**

The frontend build step exported `PUBLIC_VITE_DOCS_URL=https://` (invalid URL), which crashes SvelteKit's pre-render crawler when it resolves the docs link. Separately, the docs smoke test's bare `curl https:///` exits non-zero and aborts the test step. The build now passes an empty value (the frontend components already fall back to the GitHub docs link), and the smoke test skips with a notice when the secret isn't configured.

**3. Cron triggers registered for unconfigured features can exceed the free-plan quota.**

The generated config registered up to 4 cron triggers per worker, but two drive optional features whose jobs do nothing unless configured: custom-domain polling needs Cloudflare-for-SaaS (`CF_SAAS_API_TOKEN`) and monthly stats emails need Mailgun (`MAILGUN_DOMAIN`). Against the free plan's 5-triggers-per-account limit, these registrations can fail deploys outright (schedules API error) for self-hosters without those features or with multiple workers on one account. The cron list is now derived from the same secrets that gate the features at runtime, so that fully configured deployments (like the SaaS) register exactly the current set but minimal ones register only the two core jobs. Free-plan quota is also noted in `wrangler.example.toml`.

Note: this PR's CI will show the pre-existing failures until #438 is applied. Happy to rebase after, just wanted to prepare this now while I had availability.