### PR TITLE
fix: forward already-authenticated users from /login to the dashboard

### DIFF
--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -5,9 +5,6 @@
   import Logo from "$lib/components/Logo.svelte";
   import SEO from "$lib/components/SEO.svelte";
   import { onMount } from "svelte";
-  import type { PageData } from "./$types";
-
-  const { data }: { data: PageData } = $props();
 
   let providers = $state<AuthProvider[]>([]);
   let loading = $state(true);
@@ -24,9 +21,14 @@
       page.url.searchParams.get("error") === "email_already_used";
 
     // Redirect to dashboard if user is already authenticated
-    if (data.user) {
-      await goto("/dashboard");
-      return;
+    try {
+      const user = await authApi.me();
+      if (user) {
+        await goto("/dashboard");
+        return;
+      }
+    } catch {
+      // Not authenticated — fall through and render sign-in.
     }
 
     try {


### PR DESCRIPTION
Issue: An authenticated user landing on `/login` has to log in again. The login page tries to bounce already-signed-in users straight to the dashboard, but the check never fires. `/login` is pre-rendered, so its `+page.ts` load returns `user: undefined`.

Fix: check the session directly via `authApi.me()` and redirect to the dashboard when authenticated. That's the same approach the landing page already uses. Also drops the now-unused `data` prop and `PageData` import.

CI will fail until #438 lands, then this should merge cleanly.
