### PR TITLE
fix(ui): delete-confirmation popup on link cards

### DIFF
--- a/frontend/src/lib/components/LinkCard.svelte
+++ b/frontend/src/lib/components/LinkCard.svelte
@@ -104,11 +104,13 @@
 </script>
 
 <div
-  class="relative overflow-hidden border-2 border-gray-200 hover:border-orange-500 rounded-xl transition-all duration-300 hover:shadow-lg bg-white"
+  class="relative border-2 border-gray-200 hover:border-orange-500 rounded-xl transition-all duration-300 hover:shadow-lg bg-white {showDeleteConfirm
+    ? 'z-20'
+    : ''}"
 >
   {#if isHighlighted}
     <div
-      class="absolute inset-0 bg-orange-50 pointer-events-none"
+      class="absolute inset-0 bg-orange-50 pointer-events-none rounded-xl"
       out:fade={{ duration: 1000 }}
     ></div>
   {/if}
@@ -302,7 +304,7 @@
                   variant="danger"
                   size="sm"
                 >
-                  Deleting...
+                  Delete
                 </LoadingButton>
                 <button
                   onclick={() => (showDeleteConfirm = false)}


### PR DESCRIPTION
Fix two UI issues with the link card's delete confirmation:

1. Clipping: the card root had `overflow-hidden` which also clipped the absolutely-positioned confirmation popup leaving only its top part visible.

2. Button label: once the clipping issue was fixed I saw that the confirm button read `Deleting...` at rest. Changed that to `Delete` as it's not a progress state until clicked.

(The loading button is never actually seen, as the popup closes before the delete action is confirmed, but I left that as is.)