### PR TITLE
feat: option to exclude ambiguous characters from generated codes

### DIFF
--- a/docs/openapi/main.json
+++ b/docs/openapi/main.json
@@ -2902,7 +2902,7 @@
           "Organizations"
         ],
         "summary": "Get org settings",
-        "description": "Returns organization-level settings. The forward_query_params setting is only available on Pro+ tiers",
+        "description": "Returns organization-level settings (forward_query_params, exclude_ambiguous_chars). The forward_query_params setting is only available on Pro+ tiers",
         "operationId": "handle_get_org_settings",
         "parameters": [
           {
@@ -2940,7 +2940,7 @@
           "Organizations"
         ],
         "summary": "Update org settings",
-        "description": "Updates organization-level settings. forward_query_params requires Pro+ tier. Caller must be owner or admin",
+        "description": "Updates organization-level settings. Omitted fields are unchanged. Enabling forward_query_params requires Pro+ tier. Caller must be owner or admin",
         "operationId": "handle_update_org_settings",
         "parameters": [
           {

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -121,6 +121,7 @@ export interface UpdateLinkRequest {
 
 export interface OrgSettings {
   forward_query_params: boolean;
+  exclude_ambiguous_chars: boolean;
 }
 
 export interface ApiError {

--- a/frontend/src/routes/dashboard/org/+page.svelte
+++ b/frontend/src/routes/dashboard/org/+page.svelte
@@ -339,7 +339,7 @@
     return null;
   });
 
-  // Org settings: forward_query_params
+  // Org settings: forward_query_params, exclude_ambiguous_chars
   let orgSettings = $state<OrgSettings | null>(null);
   let settingsError = $state("");
   let settingsSaving = $state(false);
@@ -482,14 +482,12 @@
     }
   }
 
-  async function toggleForwardQueryParams(value: boolean) {
+  async function updateOrgSettings(patch: Partial<OrgSettings>) {
     if (!orgDetails) return;
     settingsSaving = true;
     settingsError = "";
     try {
-      orgSettings = await orgsApi.updateOrgSettings(orgDetails.org.id, {
-        forward_query_params: value
-      });
+      orgSettings = await orgsApi.updateOrgSettings(orgDetails.org.id, patch);
       actionSuccess = "Organization settings updated.";
       setTimeout(() => (actionSuccess = ""), 3000);
     } catch (e: unknown) {
@@ -501,6 +499,14 @@
     } finally {
       settingsSaving = false;
     }
+  }
+
+  async function toggleForwardQueryParams(value: boolean) {
+    await updateOrgSettings({ forward_query_params: value });
+  }
+
+  async function toggleExcludeAmbiguousChars(value: boolean) {
+    await updateOrgSettings({ exclude_ambiguous_chars: value });
   }
 
   // Logo management
@@ -1075,17 +1081,15 @@
         {/if}
       </div>
 
-      <!-- Pro Features / org settings card -->
-      {#if isPro}
-        <div class="bg-white rounded-xl border border-gray-200 p-6 mb-6">
-          <h2 class="text-lg font-semibold text-gray-900 mb-1">
-            Link Defaults
-          </h2>
-          <p class="text-sm text-gray-500 mb-4">
-            Default settings applied to new and edited links. Changes here do
-            not retroactively update existing links.
-          </p>
+      <!-- Link Defaults / org settings card -->
+      <div class="bg-white rounded-xl border border-gray-200 p-6 mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-1">Link Defaults</h2>
+        <p class="text-sm text-gray-500 mb-4">
+          Default settings applied to new and edited links. Changes here do not
+          retroactively update existing links.
+        </p>
 
+        {#if isPro}
           <div class="flex items-start gap-4 py-3 border-t border-gray-100">
             <div class="flex-1">
               <label
@@ -1134,12 +1138,62 @@
               />
             </div>
           </div>
+        {/if}
 
-          {#if settingsError}
-            <p class="mt-2 text-sm text-red-600">{settingsError}</p>
-          {/if}
+        <div class="flex items-start gap-4 py-3 border-t border-gray-100">
+          <div class="flex-1">
+            <label
+              for="org-exclude-ambiguous-chars"
+              class="block text-sm font-medium text-gray-900"
+            >
+              Exclude ambiguous characters from generated codes
+            </label>
+            <p class="text-xs text-gray-500 mt-0.5">
+              When enabled, randomly generated short codes omit easily confused
+              characters (0, O, I, l), making links easier to read and type.
+              Custom codes are unaffected.
+            </p>
+          </div>
+          <div class="flex items-center gap-2">
+            {#if settingsSaving}
+              <svg
+                class="animate-spin w-4 h-4 text-gray-400"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                ></circle>
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
+              </svg>
+            {/if}
+            <input
+              type="checkbox"
+              id="org-exclude-ambiguous-chars"
+              checked={orgSettings?.exclude_ambiguous_chars ?? false}
+              disabled={settingsSaving || !isOwner}
+              onchange={(e) =>
+                toggleExcludeAmbiguousChars(
+                  (e.target as HTMLInputElement).checked
+                )}
+              class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 disabled:opacity-50"
+            />
+          </div>
         </div>
-      {/if}
+
+        {#if settingsError}
+          <p class="mt-2 text-sm text-red-600">{settingsError}</p>
+        {/if}
+      </div>
 
       <!-- Org Logo Card (Pro+) -->
       <div class="bg-white rounded-xl border border-gray-200 p-6 mb-6">

--- a/migrations/0040_exclude_ambiguous_chars.sql
+++ b/migrations/0040_exclude_ambiguous_chars.sql
@@ -1,0 +1,3 @@
+-- Org-level default: exclude ambiguous characters (0, O, I, l) from
+-- randomly generated short codes by using the Base58 alphabet
+ALTER TABLE organizations ADD COLUMN exclude_ambiguous_chars INTEGER NOT NULL DEFAULT 0;

--- a/src/api/links/create.rs
+++ b/src/api/links/create.rs
@@ -2,7 +2,7 @@ use crate::auth;
 use crate::kv;
 use crate::middleware::{RateLimitConfig, RateLimiter, is_kv_rate_limiting_enabled};
 use crate::models::link::{CreateLinkRequest, Link, LinkStatus};
-use crate::repositories::CustomDomainRepository;
+use crate::repositories::{CustomDomainRepository, OrgRepository};
 use crate::services::{LinkService, SettingsService};
 use crate::utils::validate_and_normalize_tags;
 use crate::utils::{now_timestamp, validate_short_code, validate_url};
@@ -250,6 +250,9 @@ pub async fn handle_create_link(mut req: Request, ctx: RouteContext<()>) -> Resu
 
         custom_code
     } else {
+        let exclude_ambiguous = OrgRepository::new()
+            .get_exclude_ambiguous_chars(&db, org_id)
+            .await?;
         link_service
             .generate_progressive_short_code(
                 &kv,
@@ -257,6 +260,7 @@ pub async fn handle_create_link(mut req: Request, ctx: RouteContext<()>) -> Resu
                 &ctx.env,
                 lengths.min_random_length,
                 lengths.system_min_length,
+                exclude_ambiguous,
             )
             .await?
     };

--- a/src/api/links/import.rs
+++ b/src/api/links/import.rs
@@ -1,6 +1,7 @@
 use crate::auth;
 use crate::kv;
 use crate::models::link::{Link, LinkStatus};
+use crate::repositories::OrgRepository;
 use crate::services::{LinkService, SettingsService};
 use crate::utils::validate_and_normalize_tags;
 use crate::utils::{now_timestamp, validate_short_code, validate_url};
@@ -96,6 +97,10 @@ pub async fn handle_import_links(mut req: Request, ctx: RouteContext<()>) -> Res
 
     // Fetch all code length settings in a single query for performance
     let lengths = SettingsService::new().get_code_length_settings(&db).await?;
+    // Org-level default: whether generated codes exclude ambiguous characters
+    let exclude_ambiguous = OrgRepository::new()
+        .get_exclude_ambiguous_chars(&db, org_id)
+        .await?;
 
     let mut created: usize = 0;
     let mut skipped: usize = 0;
@@ -195,6 +200,7 @@ pub async fn handle_import_links(mut req: Request, ctx: RouteContext<()>) -> Res
                             &ctx.env,
                             lengths.min_random_length,
                             lengths.system_min_length,
+                            exclude_ambiguous,
                         )
                         .await
                     {
@@ -230,6 +236,7 @@ pub async fn handle_import_links(mut req: Request, ctx: RouteContext<()>) -> Res
                     &ctx.env,
                     lengths.min_random_length,
                     lengths.system_min_length,
+                    exclude_ambiguous,
                 )
                 .await
             {

--- a/src/api/orgs/settings.rs
+++ b/src/api/orgs/settings.rs
@@ -13,7 +13,7 @@ use worker::*;
     path = "/api/orgs/{id}/settings",
     tag = "Organizations",
     summary = "Get org settings",
-    description = "Returns organization-level settings. The forward_query_params setting is only available on Pro+ tiers",
+    description = "Returns organization-level settings (forward_query_params, exclude_ambiguous_chars). The forward_query_params setting is only available on Pro+ tiers",
     params(
         ("id" = String, Path, description = "Organization ID"),
     ),
@@ -39,13 +39,11 @@ async fn inner_get_org_settings(req: Request, ctx: RouteContext<()>) -> Result<R
         .to_string();
 
     let db = ctx.env.get_binding::<D1Database>("rushomon")?;
-    let forward_query_params = OrgService::new()
+    let settings = OrgService::new()
         .get_org_settings(&db, &org_id, &user_ctx.user_id)
         .await?;
 
-    Ok(Response::from_json(&serde_json::json!({
-        "forward_query_params": forward_query_params
-    }))?)
+    Ok(Response::from_json(&settings)?)
 }
 
 #[utoipa::path(
@@ -53,7 +51,7 @@ async fn inner_get_org_settings(req: Request, ctx: RouteContext<()>) -> Result<R
     path = "/api/orgs/{id}/settings",
     tag = "Organizations",
     summary = "Update org settings",
-    description = "Updates organization-level settings. forward_query_params requires Pro+ tier. Caller must be owner or admin",
+    description = "Updates organization-level settings. Omitted fields are unchanged. Enabling forward_query_params requires Pro+ tier. Caller must be owner or admin",
     params(
         ("id" = String, Path, description = "Organization ID"),
     ),
@@ -89,15 +87,29 @@ async fn inner_update_org_settings(
         .await
         .map_err(|_| AppError::BadRequest("Invalid JSON body".to_string()))?;
 
-    let forward = body["forward_query_params"].as_bool().ok_or_else(|| {
-        AppError::BadRequest("forward_query_params (boolean) is required".to_string())
-    })?;
+    let forward = match body.get("forward_query_params") {
+        None => None,
+        Some(v) => Some(v.as_bool().ok_or_else(|| {
+            AppError::BadRequest("forward_query_params must be a boolean".to_string())
+        })?),
+    };
+    let exclude_ambiguous = match body.get("exclude_ambiguous_chars") {
+        None => None,
+        Some(v) => Some(v.as_bool().ok_or_else(|| {
+            AppError::BadRequest("exclude_ambiguous_chars must be a boolean".to_string())
+        })?),
+    };
 
-    let updated_forward = OrgService::new()
-        .update_org_settings(&db, &org_id, &user_ctx.user_id, forward)
+    if forward.is_none() && exclude_ambiguous.is_none() {
+        return Err(AppError::BadRequest(
+            "At least one setting (forward_query_params, exclude_ambiguous_chars) is required"
+                .to_string(),
+        ));
+    }
+
+    let updated = OrgService::new()
+        .update_org_settings(&db, &org_id, &user_ctx.user_id, forward, exclude_ambiguous)
         .await?;
 
-    Ok(Response::from_json(&serde_json::json!({
-        "forward_query_params": updated_forward
-    }))?)
+    Ok(Response::from_json(&updated)?)
 }

--- a/src/repositories/org_repository.rs
+++ b/src/repositories/org_repository.rs
@@ -521,6 +521,39 @@ impl OrgRepository {
         Ok(())
     }
 
+    /// Get the org-level exclude_ambiguous_chars setting
+    pub async fn get_exclude_ambiguous_chars(&self, db: &D1Database, org_id: &str) -> Result<bool> {
+        let stmt = db.prepare(
+            "SELECT COALESCE(exclude_ambiguous_chars, 0) as exclude_ambiguous_chars
+             FROM organizations
+             WHERE id = ?1",
+        );
+        let result = stmt
+            .bind(&[org_id.into()])?
+            .first::<serde_json::Value>(None)
+            .await?;
+        Ok(result
+            .and_then(|r| r["exclude_ambiguous_chars"].as_f64())
+            .map(|v| v != 0.0)
+            .unwrap_or(false))
+    }
+
+    /// Update the org-level exclude_ambiguous_chars setting
+    pub async fn set_exclude_ambiguous_chars(
+        &self,
+        db: &D1Database,
+        org_id: &str,
+        exclude: bool,
+    ) -> Result<()> {
+        let stmt =
+            db.prepare("UPDATE organizations SET exclude_ambiguous_chars = ?1 WHERE id = ?2");
+        let value: i64 = if exclude { 1 } else { 0 };
+        stmt.bind(&[(value as f64).into(), org_id.into()])?
+            .run()
+            .await?;
+        Ok(())
+    }
+
     /// Get the org logo_url (nullable)
     pub async fn get_logo_url(&self, db: &D1Database, org_id: &str) -> Result<Option<String>> {
         let stmt = db.prepare("SELECT logo_url FROM organizations WHERE id = ?1");

--- a/src/services/link_service.rs
+++ b/src/services/link_service.rs
@@ -8,7 +8,7 @@ use crate::repositories::{
     BillingRepository, BlacklistRepository, LinkRepository, SettingsRepository, TagRepository,
 };
 use crate::utils::AppError;
-use crate::utils::short_code::{DEFAULT_COLLISION_THRESHOLD, generate_short_code_with_length};
+use crate::utils::short_code::{DEFAULT_COLLISION_THRESHOLD, generate_short_code_with_charset};
 use chrono::Datelike;
 use worker::d1::D1Database;
 use worker::kv::KvStore;
@@ -522,6 +522,7 @@ impl LinkService {
         env: &worker::Env,
         admin_min_length: usize,
         system_min_length: usize,
+        exclude_ambiguous: bool,
     ) -> worker::Result<String> {
         let collision_threshold = env
             .var("COLLISION_THRESHOLD")
@@ -534,7 +535,7 @@ impl LinkService {
         let mut current_length_attempts = 0;
 
         loop {
-            let code = generate_short_code_with_length(current_length);
+            let code = generate_short_code_with_charset(current_length, exclude_ambiguous);
 
             if !crate::kv::links::short_code_exists(kv, &code).await? {
                 return Ok(code);

--- a/src/services/org_service.rs
+++ b/src/services/org_service.rs
@@ -9,6 +9,13 @@ use chrono::Datelike;
 use worker::d1::D1Database;
 use worker::kv::KvStore;
 
+/// Org-level settings (defaults applied to new links)
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct OrgSettings {
+    pub forward_query_params: bool,
+    pub exclude_ambiguous_chars: bool,
+}
+
 /// Service for organization-related business logic
 #[derive(Default)]
 pub struct OrgService;
@@ -323,29 +330,33 @@ impl OrgService {
 
     // ─── Org Settings ─────────────────────────────────────────────────────────
 
-    /// Get org settings (forward_query_params) with membership check.
+    /// Get org settings with membership check.
     pub async fn get_org_settings(
         &self,
         db: &D1Database,
         org_id: &str,
         user_id: &str,
-    ) -> Result<bool, AppError> {
+    ) -> Result<OrgSettings, AppError> {
         let repo = OrgRepository::new();
         if repo.get_member(db, org_id, user_id).await?.is_none() {
             return Err(AppError::NotFound("Organization not found".to_string()));
         }
-        let forward_query_params = repo.get_forward_query_params(db, org_id).await?;
-        Ok(forward_query_params)
+        Ok(OrgSettings {
+            forward_query_params: repo.get_forward_query_params(db, org_id).await?,
+            exclude_ambiguous_chars: repo.get_exclude_ambiguous_chars(db, org_id).await?,
+        })
     }
 
-    /// Update org settings (forward_query_params) with owner/admin and tier checks.
+    /// Update org settings with owner/admin checks. Fields left as None are
+    /// unchanged. Enabling forward_query_params additionally requires Pro+.
     pub async fn update_org_settings(
         &self,
         db: &D1Database,
         org_id: &str,
         user_id: &str,
-        forward_query_params: bool,
-    ) -> Result<bool, AppError> {
+        forward_query_params: Option<bool>,
+        exclude_ambiguous_chars: Option<bool>,
+    ) -> Result<OrgSettings, AppError> {
         let repo = OrgRepository::new();
 
         self.require_owner_or_admin(
@@ -356,24 +367,33 @@ impl OrgService {
         )
         .await?;
 
-        let org = repo
-            .get_by_id(db, org_id)
-            .await?
-            .ok_or_else(|| AppError::Internal("Organization not found".to_string()))?;
+        if let Some(forward) = forward_query_params {
+            let org = repo
+                .get_by_id(db, org_id)
+                .await?
+                .ok_or_else(|| AppError::Internal("Organization not found".to_string()))?;
 
-        let tier = self.get_org_tier(db, &org).await;
-        let is_pro_or_above = matches!(tier, Tier::Pro | Tier::Business | Tier::Unlimited);
+            let tier = self.get_org_tier(db, &org).await;
+            let is_pro_or_above = matches!(tier, Tier::Pro | Tier::Business | Tier::Unlimited);
 
-        if forward_query_params && !is_pro_or_above {
-            return Err(AppError::Forbidden(
-                "Query parameter forwarding requires a Pro plan or above.".to_string(),
-            ));
+            if forward && !is_pro_or_above {
+                return Err(AppError::Forbidden(
+                    "Query parameter forwarding requires a Pro plan or above.".to_string(),
+                ));
+            }
+
+            repo.set_forward_query_params(db, org_id, forward).await?;
         }
 
-        repo.set_forward_query_params(db, org_id, forward_query_params)
-            .await?;
-        let updated = repo.get_forward_query_params(db, org_id).await?;
-        Ok(updated)
+        if let Some(exclude) = exclude_ambiguous_chars {
+            repo.set_exclude_ambiguous_chars(db, org_id, exclude)
+                .await?;
+        }
+
+        Ok(OrgSettings {
+            forward_query_params: repo.get_forward_query_params(db, org_id).await?,
+            exclude_ambiguous_chars: repo.get_exclude_ambiguous_chars(db, org_id).await?,
+        })
     }
 
     // ─── Org Logo ─────────────────────────────────────────────────────────────

--- a/src/utils/short_code.rs
+++ b/src/utils/short_code.rs
@@ -1,6 +1,8 @@
 use rand::RngExt;
 
 const BASE62_CHARS: &[u8] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+// Standard Flickr Base58 Alphabet (no 0, O, I, or l)
+const BASE58_CHARS: &[u8] = b"123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ";
 
 /// Character set: 0-9, A-Z, a-z (62 chars)
 /// Combinations: 62^6 = 56,800,235,584 (56.8 billion)
@@ -18,11 +20,23 @@ pub fn generate_short_code() -> String {
 
 /// Generate a random base62 short code with custom length
 pub fn generate_short_code_with_length(length: usize) -> String {
+    generate_short_code_with_charset(length, false)
+}
+
+/// Generate a random short code with custom length, optionally excluding
+/// ambiguous characters (0, O, I, l) by using the Base58 alphabet
+pub fn generate_short_code_with_charset(length: usize, exclude_ambiguous: bool) -> String {
     let mut rng = rand::rng();
+    let charset = if exclude_ambiguous {
+        BASE58_CHARS
+    } else {
+        BASE62_CHARS
+    };
+
     (0..length)
         .map(|_| {
-            let idx = rng.random_range(0..BASE62_CHARS.len());
-            BASE62_CHARS[idx] as char
+            let idx = rng.random_range(0..charset.len());
+            charset[idx] as char
         })
         .collect()
 }
@@ -82,5 +96,29 @@ mod tests {
         assert_ne!(code1, code2);
         assert_ne!(code2, code3);
         assert_ne!(code1, code3);
+    }
+
+    #[test]
+    fn test_generate_base58_excludes_ambiguous_chars() {
+        // Generate 100 codes at 20 characters long to ensure a massive sample size
+        for _ in 0..100 {
+            let code = generate_short_code_with_charset(20, true);
+
+            // Mathematically guarantee these characters never appear
+            assert!(!code.contains('0'), "Generated code contained a zero!");
+            assert!(!code.contains('O'), "Generated code contained a capital O!");
+            assert!(!code.contains('I'), "Generated code contained a capital I!");
+            assert!(
+                !code.contains('l'),
+                "Generated code contained a lowercase l!"
+            );
+        }
+    }
+
+    #[test]
+    fn test_generate_base62_normal() {
+        // Just verify the default generator still works and produces the right length
+        let code = generate_short_code_with_charset(10, false);
+        assert_eq!(code.len(), 10);
     }
 }

--- a/tests/orgs_test.rs
+++ b/tests/orgs_test.rs
@@ -1051,3 +1051,168 @@ async fn test_invite_defaults_to_member_role() {
         .await
         .unwrap();
 }
+
+// ─── Org Settings ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_get_org_settings_requires_auth() {
+    let client = test_client();
+    let response = client
+        .get(format!("{}/api/orgs/some-id/settings", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_get_org_settings_returns_all_fields() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let response = client
+        .get(format!("{}/api/orgs/{}/settings", BASE_URL, org_id))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = response.json().await.unwrap();
+    assert!(
+        body["forward_query_params"].is_boolean(),
+        "forward_query_params should be a boolean"
+    );
+    assert!(
+        body["exclude_ambiguous_chars"].is_boolean(),
+        "exclude_ambiguous_chars should be a boolean"
+    );
+}
+
+#[tokio::test]
+async fn test_update_exclude_ambiguous_chars_partial_update() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    // Record the current settings so the partial-update assertion is exact
+    let before: Value = client
+        .get(format!("{}/api/orgs/{}/settings", BASE_URL, org_id))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let forward_before = before["forward_query_params"].as_bool().unwrap();
+
+    let response = client
+        .patch(format!("{}/api/orgs/{}/settings", BASE_URL, org_id))
+        .json(&json!({"exclude_ambiguous_chars": true}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value = response.json().await.unwrap();
+    assert!(body["exclude_ambiguous_chars"].as_bool().unwrap());
+    assert_eq!(
+        body["forward_query_params"].as_bool().unwrap(),
+        forward_before,
+        "Omitted fields should be unchanged"
+    );
+
+    // Restore
+    let response = client
+        .patch(format!("{}/api/orgs/{}/settings", BASE_URL, org_id))
+        .json(&json!({"exclude_ambiguous_chars": false}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = response.json().await.unwrap();
+    assert!(!body["exclude_ambiguous_chars"].as_bool().unwrap());
+}
+
+#[tokio::test]
+async fn test_update_org_settings_requires_at_least_one_field() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let response = client
+        .patch(format!("{}/api/orgs/{}/settings", BASE_URL, org_id))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_update_org_settings_rejects_non_boolean() {
+    let client = authenticated_client();
+    let org_id = get_primary_test_org_id().await;
+
+    let response = client
+        .patch(format!("{}/api/orgs/{}/settings", BASE_URL, org_id))
+        .json(&json!({"exclude_ambiguous_chars": "yes"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_exclude_ambiguous_chars_affects_generated_codes() {
+    let client = authenticated_client();
+
+    // Link creation uses the session's current org, which other concurrently
+    // running tests can switch. Enable the setting on every org the user owns
+    // so the generated codes are Base58 regardless of the active org.
+    let orgs_body: Value = client
+        .get(format!("{}/api/orgs", BASE_URL))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let owned_org_ids: Vec<String> = orgs_body["orgs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|o| o["role"].as_str() == Some("owner"))
+        .filter_map(|o| o["id"].as_str().map(|s| s.to_string()))
+        .collect();
+    assert!(!owned_org_ids.is_empty());
+
+    for org_id in &owned_org_ids {
+        let response = client
+            .patch(format!("{}/api/orgs/{}/settings", BASE_URL, org_id))
+            .json(&json!({"exclude_ambiguous_chars": true}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    // Generated codes must not contain ambiguous characters (0, O, I, l)
+    for i in 0..5 {
+        let code =
+            create_link_and_get_code(&format!("https://example.com/ambiguous-test-{}", i)).await;
+        assert!(
+            !code.contains(['0', 'O', 'I', 'l']),
+            "Generated code '{}' contains an ambiguous character",
+            code
+        );
+    }
+
+    // Restore
+    for org_id in &owned_org_ids {
+        let response = client
+            .patch(format!("{}/api/orgs/{}/settings", BASE_URL, org_id))
+            .json(&json!({"exclude_ambiguous_chars": false}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}


### PR DESCRIPTION
Implements #215. Reworked. As discussed this is org-specific rather than instance-wide.

This adds an organization-level **Exclude ambiguous characters** setting (default off). When enabled, random short-code generation uses the Flickr Base58 alphabet (no `0`, `O`, `I`, `l`) instead of Base62 at a modest namespace cost. Custom codes and internal ID generation (API keys, billing IDs etc) are unaffected.

- Base62 is preserved as the default
- Charset handling in `generate_short_code_with_charset` in `src/utils/short_code.rs`
- The existing generate_short_code_with_length delegates to it so non-link callers always use the Base62 alphabet
- Stored as an organizations column (like forward_query_params org default), added via migration 0040
- Exposed via GET/PATCH `/api/orgs/{id}/settings`
- PATCH treats each setting as optional so callers can update either independently (backwards compatible as forward_query_params was previously required)
- Link generation fetches the org setting for create and CSV import
- Toggle in the org settings Link Defaults section
- Available on all tiers (the card itself is no longer gated, but the Pro-only forward_query_params row still is)
- Integration tests: org settings API contract, partial updates, and a behavioral test that generated codes exclude ambiguous characters
- Unit tests assert the exclusion guarantee across the charset
- OpenAPI spec updated

I left this un-gated, but it would be simple to gate it as well if you prefer for SAAS.

Running in production on my instances.