### PR TITLE
feat: enable Rust/Wasm panic recovery with --panic-unwind

### DIFF
--- a/.github/workflows/deploy-ephemeral.yml
+++ b/.github/workflows/deploy-ephemeral.yml
@@ -90,10 +90,10 @@ jobs:
       - name: Install wrangler and worker-build
         run: |
           npm install -g wrangler
-          cargo install -q worker-build --version 0.8.4
+          cargo install -q worker-build --version 0.8.5
 
       - name: Build Worker
-        run: worker-build --release
+        run: worker-build --release --panic-unwind
 
       - name: Create D1 Database
         id: create_d1
@@ -241,7 +241,7 @@ jobs:
           head_sampling_rate = 0.1
 
           [build]
-          command = "cargo install -q worker-build --version 0.8.4 && worker-build --release"
+          command = "cargo install -q worker-build --version 0.8.5 && worker-build --release --panic-unwind"
 
           # Cron Triggers for scheduled tasks
           # Format: array of cron expressions (Cloudflare doesn't support named triggers)

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -173,10 +173,10 @@ jobs:
       - name: Install wrangler and worker-build
         run: |
           npm install -g wrangler
-          cargo install -q worker-build --version 0.8.4
+          cargo install -q worker-build --version 0.8.5
 
       - name: Build Worker
-        run: worker-build --release
+        run: worker-build --release --panic-unwind
 
       - name: Install Frontend Dependencies
         working-directory: frontend

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -251,10 +251,10 @@ jobs:
         run: npm install -g wrangler
 
       - name: Install worker-build
-        run: cargo install worker-build --version 0.8.4
+        run: cargo install worker-build --version 0.8.5
 
       - name: Build backend
-        run: worker-build --release
+        run: worker-build --release --panic-unwind
 
       - name: Install frontend dependencies
         working-directory: ./frontend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install wrangler and worker-build
         run: |
           npm install -g wrangler
-          cargo install -q worker-build --version 0.8.4
+          cargo install -q worker-build --version 0.8.5
 
       - name: Create frontend build stub
         run: |
@@ -144,7 +144,7 @@ jobs:
           echo '<html><body>stub</body></html>' > frontend/build/index.html
 
       - name: Build Worker
-        run: worker-build --release
+        run: worker-build --release --panic-unwind
 
       - name: Create wrangler.toml for tests
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-worker = { version = "0.8.3", features = ["d1"] }
-wasm-bindgen = { version = "0.2.122", features = ["serde-serialize"] }
+worker = { version = "0.8.5", features = ["d1"] }
+wasm-bindgen = { version = "0.2.126", features = ["serde-serialize"] }
 web-sys = { version = "0.3", features = ["Window", "Request", "RequestInit", "Response", "Headers", "RequestMode"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -66,7 +66,7 @@ optional = true
 [profile.release]
 opt-level = "s"
 lto = true
-strip = true
+strip = "debuginfo"
 codegen-units = 1
 
 [workspace.lints.clippy]

--- a/scripts/lib/deployment.sh
+++ b/scripts/lib/deployment.sh
@@ -207,7 +207,7 @@ check_build_prerequisites() {
   # Check worker-build
   if ! command -v worker-build &>/dev/null; then
     warning "worker-build not found, installing..."
-    cargo install worker-build || {
+    cargo install worker-build --version 0.8.5 || {
       error "Failed to install worker-build"
       return 1
     }
@@ -229,7 +229,7 @@ build_backend() {
   cd "$project_root" || return 1
 
   # Run worker-build in release mode
-  worker-build --release || {
+  worker-build --release --panic-unwind || {
     error "Backend build failed"
     return 1
   }

--- a/scripts/start-local-environment.sh
+++ b/scripts/start-local-environment.sh
@@ -148,7 +148,7 @@ fi
 
 # Build the worker first to avoid timeouts during startup
 echo "🔨 Building worker..."
-worker-build --release --quiet
+worker-build --release --panic-unwind --quiet
 
 # Note: R2 bucket is created automatically by wrangler dev --local
 # Remote bucket creation is skipped for local development


### PR DESCRIPTION
- Pin worker-build to 0.8.5 across CI, local dev, and deployment scripts
- Build worker with --panic-unwind in all workflows and shell helpers
- Change release profile strip = true to "debuginfo" to preserve wasm-bindgen reference-types metadata

Fixes #338 