### PR TITLE
feat: pre-aggregate monthly link clicks and log atomically with D1 batch

### DIFF
--- a/migrations/0041_link_monthly_clicks.sql
+++ b/migrations/0041_link_monthly_clicks.sql
@@ -1,0 +1,31 @@
+-- Migration 0041: Per-link monthly click counters
+-- Pre-aggregates clicks per (link_id, month) so the monthly stats email can
+-- compute org totals and top links without scanning the entire analytics_events table.
+
+CREATE TABLE IF NOT EXISTS link_monthly_clicks (
+  link_id TEXT NOT NULL,
+  org_id TEXT NOT NULL,
+  year_month TEXT NOT NULL,  -- Format: "YYYY-MM"
+  clicks INTEGER DEFAULT 0,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (link_id, year_month),
+  FOREIGN KEY (link_id) REFERENCES links(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_link_monthly_clicks_org
+  ON link_monthly_clicks(org_id, year_month);
+
+-- Backfill from existing analytics events. This is a one-time scan of the
+-- analytics_events table; afterwards the email job reads only this small table.
+INSERT INTO link_monthly_clicks (link_id, org_id, year_month, clicks, updated_at)
+SELECT
+  link_id,
+  org_id,
+  strftime('%Y-%m', timestamp, 'unixepoch') AS year_month,
+  COUNT(*) AS clicks,
+  strftime('%s', 'now') AS updated_at
+FROM analytics_events
+GROUP BY link_id, org_id, strftime('%Y-%m', timestamp, 'unixepoch')
+ON CONFLICT(link_id, year_month) DO UPDATE SET
+  clicks = excluded.clicks,
+  updated_at = excluded.updated_at;

--- a/src/api/links/redirect.rs
+++ b/src/api/links/redirect.rs
@@ -4,6 +4,7 @@ use crate::models::{AnalyticsEvent, link::LinkStatus};
 use crate::repositories::{CustomDomainRepository, LinkRepository};
 use crate::utils::device::{DeviceType, detect_device};
 use crate::utils::{get_client_ip, get_frontend_url, hash_ip, now_timestamp};
+use chrono::TimeZone;
 use std::future::Future;
 use std::pin::Pin;
 use worker::d1::D1Database;
@@ -257,7 +258,27 @@ pub async fn handle_redirect(
             city,
         };
 
-        if let Err(e) = repo.log_analytics_event(&db, &event).await {
+        let year_month = chrono::Utc
+            .timestamp_opt(now, 0)
+            .single()
+            .map(|dt| dt.format("%Y-%m").to_string())
+            .unwrap_or_default();
+        if !year_month.is_empty() {
+            if let Err(e) = repo
+                .log_analytics_event_and_increment(&db, &event, &year_month)
+                .await
+            {
+                console_log!(
+                    "{}",
+                    serde_json::json!({
+                        "event": "analytics_event_failed",
+                        "link_id": link_id,
+                        "error": e.to_string(),
+                        "level": "error"
+                    })
+                );
+            }
+        } else if let Err(e) = repo.log_analytics_event(&db, &event).await {
             console_log!(
                 "{}",
                 serde_json::json!({

--- a/src/models/analytics.rs
+++ b/src/models/analytics.rs
@@ -548,23 +548,6 @@ pub struct TopLinkCount {
     pub custom_domain: Option<String>,
 }
 
-/// Pre-aggregated click count for a single link in a calendar month.
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct LinkMonthlyClick {
-    #[schema(example = "link-123")]
-    pub link_id: String,
-    #[schema(example = "org-123")]
-    pub org_id: String,
-    /// Calendar month in "YYYY-MM" format.
-    #[schema(example = "2026-06")]
-    pub year_month: String,
-    #[schema(example = 42)]
-    pub clicks: i64,
-    #[schema(example = 1717200000)]
-    pub updated_at: i64,
-}
-
 #[derive(Debug, Serialize, ToSchema)]
 pub struct OrgAnalyticsResponse {
     #[schema(example = 1500)]

--- a/src/models/analytics.rs
+++ b/src/models/analytics.rs
@@ -548,6 +548,23 @@ pub struct TopLinkCount {
     pub custom_domain: Option<String>,
 }
 
+/// Pre-aggregated click count for a single link in a calendar month.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LinkMonthlyClick {
+    #[schema(example = "link-123")]
+    pub link_id: String,
+    #[schema(example = "org-123")]
+    pub org_id: String,
+    /// Calendar month in "YYYY-MM" format.
+    #[schema(example = "2026-06")]
+    pub year_month: String,
+    #[schema(example = 42)]
+    pub clicks: i64,
+    #[schema(example = 1717200000)]
+    pub updated_at: i64,
+}
+
 #[derive(Debug, Serialize, ToSchema)]
 pub struct OrgAnalyticsResponse {
     #[schema(example = 1500)]

--- a/src/repositories/analytics_repository.rs
+++ b/src/repositories/analytics_repository.rs
@@ -476,6 +476,73 @@ impl AnalyticsRepository {
         Ok(agents)
     }
 
+    // ── Monthly pre-aggregated counters ────────────────────────────────────
+
+    /// Total clicks for an org in a specific calendar month.
+    /// Reads one aggregated row per link instead of every analytics event.
+    pub async fn get_org_monthly_clicks(
+        &self,
+        db: &D1Database,
+        org_id: &str,
+        year_month: &str,
+    ) -> Result<i64> {
+        let stmt = db.prepare(
+            "SELECT COALESCE(SUM(clicks), 0) as count
+             FROM link_monthly_clicks
+             WHERE org_id = ?1 AND year_month = ?2",
+        );
+        let result = stmt
+            .bind(&[org_id.into(), year_month.into()])?
+            .first::<serde_json::Value>(None)
+            .await?;
+        match result {
+            Some(val) => Ok(val["count"].as_f64().unwrap_or(0.0) as i64),
+            None => Ok(0),
+        }
+    }
+
+    /// Top links for an org in a specific calendar month.
+    /// Only reads the small link_monthly_clicks table, ordered by the counter.
+    pub async fn get_org_monthly_top_links(
+        &self,
+        db: &D1Database,
+        org_id: &str,
+        year_month: &str,
+        limit: i64,
+    ) -> Result<Vec<TopLinkCount>> {
+        let stmt = db.prepare(
+            "SELECT lmc.link_id, l.short_code, l.title, l.custom_domain, lmc.clicks as count
+             FROM link_monthly_clicks lmc
+             JOIN links l ON lmc.link_id = l.id
+             WHERE lmc.org_id = ?1 AND lmc.year_month = ?2
+             ORDER BY lmc.clicks DESC
+             LIMIT ?3",
+        );
+        let results = stmt
+            .bind(&[org_id.into(), year_month.into(), (limit as f64).into()])?
+            .all()
+            .await?;
+        let rows = results.results::<serde_json::Value>()?;
+        let links = rows
+            .iter()
+            .filter_map(|row| {
+                let link_id = row["link_id"].as_str()?.to_string();
+                let short_code = row["short_code"].as_str()?.to_string();
+                let title = row["title"].as_str().map(|s| s.to_string());
+                let custom_domain = row["custom_domain"].as_str().map(|s| s.to_string());
+                let count = row["count"].as_f64()? as i64;
+                Some(TopLinkCount {
+                    link_id,
+                    short_code,
+                    title,
+                    count,
+                    custom_domain,
+                })
+            })
+            .collect();
+        Ok(links)
+    }
+
     // ── Usage queries ────────────────────────────────────────────────────────
 
     /// Get monthly counter for billing account

--- a/src/repositories/link_repository.rs
+++ b/src/repositories/link_repository.rs
@@ -552,6 +552,64 @@ impl LinkRepository {
         Ok(())
     }
 
+    /// Log an analytics event and atomically increment the per-link monthly click counter.
+    /// D1's `batch` API executes the statements sequentially in a single implicit transaction,
+    /// so if either insert fails the whole batch is rolled back.
+    pub async fn log_analytics_event_and_increment(
+        &self,
+        db: &D1Database,
+        event: &AnalyticsEvent,
+        year_month: &str,
+    ) -> Result<()> {
+        let insert_event = db.prepare(
+            "INSERT INTO analytics_events (link_id, org_id, timestamp, referrer, user_agent, country, city)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)"
+        );
+        let insert_counter = db.prepare(
+            "INSERT INTO link_monthly_clicks (link_id, org_id, year_month, clicks, updated_at)
+             VALUES (?1, ?2, ?3, 1, ?4)
+             ON CONFLICT(link_id, year_month) DO UPDATE SET
+               clicks = clicks + 1,
+               updated_at = excluded.updated_at",
+        );
+
+        let insert_event = insert_event.bind(&[
+            event.link_id.clone().into(),
+            event.org_id.clone().into(),
+            (event.timestamp as f64).into(),
+            event
+                .referrer
+                .clone()
+                .map(|t| t.into())
+                .unwrap_or(JsValue::NULL),
+            event
+                .user_agent
+                .clone()
+                .map(|t| t.into())
+                .unwrap_or(JsValue::NULL),
+            event
+                .country
+                .clone()
+                .map(|t| t.into())
+                .unwrap_or(JsValue::NULL),
+            event
+                .city
+                .clone()
+                .map(|t| t.into())
+                .unwrap_or(JsValue::NULL),
+        ])?;
+
+        let insert_counter = insert_counter.bind(&[
+            event.link_id.clone().into(),
+            event.org_id.clone().into(),
+            year_month.into(),
+            (event.timestamp as f64).into(),
+        ])?;
+
+        let _ = db.batch(vec![insert_event, insert_counter]).await?;
+        Ok(())
+    }
+
     // ─── Tags ─────────────────────────────────────────────────────────────────
 
     /// Get all tags for a single link, sorted alphabetically

--- a/src/services/email_notification_service.rs
+++ b/src/services/email_notification_service.rs
@@ -9,46 +9,13 @@ use crate::repositories::notification_preferences_repository::NotificationPrefer
 use crate::repositories::{AnalyticsRepository, LinkRepository, OrgRepository};
 use crate::utils::email::{OrgMonthlySummary, TopLinkSummary, send_monthly_stats_email};
 use crate::utils::{get_frontend_url, is_mailgun_configured};
-use chrono::{Datelike, TimeZone, Utc};
+use chrono::{Datelike, Utc};
 use worker::d1::D1Database;
 use worker::{Env, console_error, console_log, console_warn};
 
-/// Compute the [start, end) Unix timestamps (inclusive) for the previous full
-/// calendar month, and the month before that, relative to `now_utc`.
-///
-/// Returns `(prev_start, prev_end, prev_prev_start, prev_prev_end)`.
-fn previous_month_ranges(now_utc: chrono::DateTime<Utc>) -> (i64, i64, i64, i64) {
-    let this_year = now_utc.year();
-    let this_month = now_utc.month();
-
-    // Previous month
-    let (prev_year, prev_month) = if this_month == 1 {
-        (this_year - 1, 12u32)
-    } else {
-        (this_year, this_month - 1)
-    };
-
-    // Month before that
-    let (prev_prev_year, prev_prev_month) = if prev_month == 1 {
-        (prev_year - 1, 12u32)
-    } else {
-        (prev_year, prev_month - 1)
-    };
-
-    // Build timestamp for first day of a month (midnight UTC)
-    let month_start_ts = |y: i32, m: u32| -> i64 {
-        Utc.with_ymd_and_hms(y, m, 1, 0, 0, 0)
-            .single()
-            .map(|dt| dt.timestamp())
-            .unwrap_or(0)
-    };
-
-    let prev_start = month_start_ts(prev_year, prev_month);
-    let prev_end = month_start_ts(this_year, this_month) - 1;
-    let prev_prev_start = month_start_ts(prev_prev_year, prev_prev_month);
-    let prev_prev_end = prev_start - 1;
-
-    (prev_start, prev_end, prev_prev_start, prev_prev_end)
+/// Format a year/month pair as a "YYYY-MM" string for the counter table.
+fn year_month_label(year: i32, month: u32) -> String {
+    format!("{:04}-{:02}", year, month)
 }
 
 /// Format a year/month pair as a human-readable label, e.g. "May 2026".
@@ -87,8 +54,14 @@ pub async fn send_monthly_stats_to_all_users(db: &D1Database, env: &Env) -> (usi
     } else {
         (now.year(), now.month() - 1)
     };
+    let (prev_prev_year, prev_prev_month) = if prev_month == 1 {
+        (prev_year - 1, 12u32)
+    } else {
+        (prev_year, prev_month - 1)
+    };
     let label = month_label(prev_year, prev_month);
-    let (prev_start, prev_end, prev_prev_start, prev_prev_end) = previous_month_ranges(now);
+    let prev_year_month = year_month_label(prev_year, prev_month);
+    let prev_prev_year_month = year_month_label(prev_prev_year, prev_prev_month);
     let frontend_url = get_frontend_url(env);
 
     let prefs_repo = NotificationPreferencesRepository::new();
@@ -154,9 +127,9 @@ pub async fn send_monthly_stats_to_all_users(db: &D1Database, env: &Env) -> (usi
                 }
             };
 
-            // Total clicks in the previous month
+            // Total clicks in the previous month (from pre-aggregated counter)
             let total_clicks = match analytics_repo
-                .get_org_total_clicks_in_range(db, &org.id, prev_start, prev_end)
+                .get_org_monthly_clicks(db, &org.id, &prev_year_month)
                 .await
             {
                 Ok(c) => c,
@@ -172,7 +145,7 @@ pub async fn send_monthly_stats_to_all_users(db: &D1Database, env: &Env) -> (usi
 
             // Comparison: clicks in the month before the previous one
             let prev_month_clicks = match analytics_repo
-                .get_org_total_clicks_in_range(db, &org.id, prev_prev_start, prev_prev_end)
+                .get_org_monthly_clicks(db, &org.id, &prev_prev_year_month)
                 .await
             {
                 Ok(c) => c,
@@ -189,7 +162,7 @@ pub async fn send_monthly_stats_to_all_users(db: &D1Database, env: &Env) -> (usi
             // Top links — only fetched when there were clicks
             let top_links = if total_clicks > 0 {
                 match analytics_repo
-                    .get_org_top_links(db, &org.id, prev_start, prev_end, 5)
+                    .get_org_monthly_top_links(db, &org.id, &prev_year_month, 5)
                     .await
                 {
                     Ok(links) => links
@@ -264,63 +237,20 @@ pub async fn send_monthly_stats_to_all_users(db: &D1Database, env: &Env) -> (usi
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
-
-    #[test]
-    fn test_previous_month_ranges_mid_year() {
-        // June 3rd 2026 → previous month is May 2026, prev-prev is April 2026
-        let now = Utc.with_ymd_and_hms(2026, 6, 3, 8, 0, 0).unwrap();
-        let (prev_start, prev_end, pp_start, pp_end) = previous_month_ranges(now);
-
-        let may1 = Utc
-            .with_ymd_and_hms(2026, 5, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-        let jun1 = Utc
-            .with_ymd_and_hms(2026, 6, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-        let apr1 = Utc
-            .with_ymd_and_hms(2026, 4, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-
-        assert_eq!(prev_start, may1);
-        assert_eq!(prev_end, jun1 - 1);
-        assert_eq!(pp_start, apr1);
-        assert_eq!(pp_end, may1 - 1);
-    }
-
-    #[test]
-    fn test_previous_month_ranges_january() {
-        // January 2nd 2026 → previous month is December 2025, prev-prev is November 2025
-        let now = Utc.with_ymd_and_hms(2026, 1, 2, 8, 0, 0).unwrap();
-        let (prev_start, prev_end, pp_start, pp_end) = previous_month_ranges(now);
-
-        let dec1_2025 = Utc
-            .with_ymd_and_hms(2025, 12, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-        let jan1_2026 = Utc
-            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-        let nov1_2025 = Utc
-            .with_ymd_and_hms(2025, 11, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-
-        assert_eq!(prev_start, dec1_2025);
-        assert_eq!(prev_end, jan1_2026 - 1);
-        assert_eq!(pp_start, nov1_2025);
-        assert_eq!(pp_end, dec1_2025 - 1);
-    }
 
     #[test]
     fn test_month_label() {
         assert_eq!(month_label(2026, 5), "May 2026");
         assert_eq!(month_label(2025, 12), "December 2025");
         assert_eq!(month_label(2026, 1), "January 2026");
+    }
+
+    #[test]
+    fn test_year_month_label() {
+        assert_eq!(year_month_label(2026, 5), "2026-05");
+        assert_eq!(year_month_label(2025, 12), "2025-12");
+        assert_eq!(year_month_label(2026, 1), "2026-01");
+        assert_eq!(year_month_label(2024, 2), "2024-02");
     }
 
     #[test]
@@ -353,84 +283,5 @@ mod tests {
         // Month 0 and 13 hit the _ => "Unknown" arm — must not panic
         assert_eq!(month_label(2026, 0), "Unknown 2026");
         assert_eq!(month_label(2026, 13), "Unknown 2026");
-    }
-
-    #[test]
-    fn test_previous_month_ranges_february() {
-        // February 2026 → previous month is January 2026, prev-prev is December 2025
-        // This is the case where prev-prev wraps back across a year boundary.
-        let now = Utc.with_ymd_and_hms(2026, 2, 2, 8, 0, 0).unwrap();
-        let (prev_start, prev_end, pp_start, pp_end) = previous_month_ranges(now);
-
-        let jan1_2026 = Utc
-            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-        let feb1_2026 = Utc
-            .with_ymd_and_hms(2026, 2, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-        let dec1_2025 = Utc
-            .with_ymd_and_hms(2025, 12, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-
-        assert_eq!(prev_start, jan1_2026, "prev month should start Jan 1 2026");
-        assert_eq!(
-            prev_end,
-            feb1_2026 - 1,
-            "prev month should end at end of Jan 2026"
-        );
-        assert_eq!(
-            pp_start, dec1_2025,
-            "prev-prev month should start Dec 1 2025"
-        );
-        assert_eq!(
-            pp_end,
-            jan1_2026 - 1,
-            "prev-prev month should end at end of Dec 2025"
-        );
-    }
-
-    #[test]
-    fn test_previous_month_ranges_march() {
-        // March 2026 → previous is February, prev-prev is January (no year wrap)
-        let now = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
-        let (prev_start, prev_end, pp_start, pp_end) = previous_month_ranges(now);
-
-        let feb1 = Utc
-            .with_ymd_and_hms(2026, 2, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-        let mar1 = Utc
-            .with_ymd_and_hms(2026, 3, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-        let jan1 = Utc
-            .with_ymd_and_hms(2026, 1, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-
-        assert_eq!(prev_start, feb1);
-        assert_eq!(prev_end, mar1 - 1);
-        assert_eq!(pp_start, jan1);
-        assert_eq!(pp_end, feb1 - 1);
-    }
-
-    #[test]
-    fn test_previous_month_ranges_prev_end_is_one_second_before_current_month() {
-        // Verify the half-open interval: prev_end = first second of current month - 1
-        let now = Utc.with_ymd_and_hms(2026, 6, 3, 8, 0, 0).unwrap();
-        let (_, prev_end, _, _) = previous_month_ranges(now);
-
-        let jun1 = Utc
-            .with_ymd_and_hms(2026, 6, 1, 0, 0, 0)
-            .unwrap()
-            .timestamp();
-        assert_eq!(
-            prev_end,
-            jun1 - 1,
-            "prev_end must be exactly 1 second before the current month start"
-        );
     }
 }


### PR DESCRIPTION
- Add link_monthly_clicks table and migration to pre-aggregate clicks per link/month
- Add LinkMonthlyClick model and analytics repository queries for org-level stats
- Update redirect handler to insert analytics event and increment monthly counter in a single D1 batch
- Update monthly email service to read from link_monthly_clicks instead of scanning analytics_events
- Remove unused previous_month_ranges helper and update tests

Closes #458 