### PR TITLE
fix(frontend): close modals/slide-overs only on explicit backdrop clicks

### DIFF
--- a/frontend/src/lib/actions/backdropClose.ts
+++ b/frontend/src/lib/actions/backdropClose.ts
@@ -1,0 +1,44 @@
+import type { Action } from "svelte/action";
+
+export const backdropClose: Action<HTMLElement, () => void> = (
+  node,
+  callback
+) => {
+  let activePointerId: number | null = null;
+
+  function handlePointerDown(event: PointerEvent) {
+    if (event.target === node) {
+      activePointerId = event.pointerId;
+    }
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    if (event.pointerId === activePointerId && event.target === node) {
+      callback();
+    }
+    if (event.pointerId === activePointerId) {
+      activePointerId = null;
+    }
+  }
+
+  function handlePointerCancel(event: PointerEvent) {
+    if (event.pointerId === activePointerId) {
+      activePointerId = null;
+    }
+  }
+
+  node.addEventListener("pointerdown", handlePointerDown);
+  node.addEventListener("pointerup", handlePointerUp);
+  node.addEventListener("pointercancel", handlePointerCancel);
+
+  return {
+    update(newCallback: () => void) {
+      callback = newCallback;
+    },
+    destroy() {
+      node.removeEventListener("pointerdown", handlePointerDown);
+      node.removeEventListener("pointerup", handlePointerUp);
+      node.removeEventListener("pointercancel", handlePointerCancel);
+    }
+  };
+};

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { PUBLIC_VITE_DOCS_URL } from "$env/static/public";
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { authApi } from "$lib/api/auth";
   import { billingApi } from "$lib/api/billing";
   import { orgsApi } from "$lib/api/orgs";
@@ -253,13 +254,8 @@
 
               {#if orgSwitcherOpen}
                 <div
-                  role="button"
-                  tabindex="-1"
-                  aria-label="Close org switcher"
                   class="fixed inset-0 z-40"
-                  onclick={() => (orgSwitcherOpen = false)}
-                  onkeydown={(e) =>
-                    e.key === "Escape" && (orgSwitcherOpen = false)}
+                  use:backdropClose={() => (orgSwitcherOpen = false)}
                 ></div>
                 <div
                   class="absolute right-0 mt-1 w-72 bg-white rounded-xl border border-gray-200 shadow-lg z-50 overflow-hidden"
@@ -625,12 +621,8 @@
   >
     <!-- Backdrop -->
     <div
-      role="button"
-      tabindex="-1"
-      aria-label="Close dialog"
       class="absolute inset-0 bg-black/40"
-      onclick={() => (showCreateOrg = false)}
-      onkeydown={(e) => e.key === "Escape" && (showCreateOrg = false)}
+      use:backdropClose={() => (showCreateOrg = false)}
     ></div>
     <!-- Dialog -->
     <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-md p-6">

--- a/frontend/src/lib/components/LinkModal.svelte
+++ b/frontend/src/lib/components/LinkModal.svelte
@@ -12,6 +12,7 @@
     UtmParams
   } from "$lib/types/api";
   import { debounce, fetchUrlTitle } from "$lib/utils/url-title";
+  import { backdropClose } from "$lib/actions/backdropClose";
   import {
     DEFAULT_MIN_CUSTOM_CODE_LENGTH,
     MAX_SHORT_CODE_LENGTH
@@ -246,12 +247,6 @@
     }
   }
 
-  function handleBackdropClick(e: MouseEvent) {
-    if (e.target === e.currentTarget) {
-      handleClose();
-    }
-  }
-
   async function handleSubmit(e: Event) {
     e.preventDefault();
     loading = true;
@@ -401,15 +396,7 @@
 {#if isOpen}
   <div
     class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-    onclick={handleBackdropClick}
-    role="button"
-    tabindex="0"
-    onkeydown={(e) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        handleClose();
-      }
-    }}
+    use:backdropClose={handleClose}
   >
     <div
       class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto"

--- a/frontend/src/lib/components/OrgLinkSlideOver.svelte
+++ b/frontend/src/lib/components/OrgLinkSlideOver.svelte
@@ -4,6 +4,7 @@
     PUBLIC_VITE_API_BASE_URL,
     PUBLIC_VITE_SHORT_LINK_BASE_URL
   } from "$env/static/public";
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { linksApi } from "$lib/api/links";
   import type { LinkAnalyticsResponse, TopLinkCount } from "$lib/types/api";
   import {
@@ -192,11 +193,7 @@
 <!-- Backdrop -->
 <div
   class="fixed inset-0 bg-black/30 z-40 transition-opacity"
-  role="button"
-  tabindex="-1"
-  aria-label="Close panel"
-  onclick={onclose}
-  onkeydown={(e) => e.key === "Enter" && onclose()}
+  use:backdropClose={onclose}
 ></div>
 
 <!-- Slide-over panel -->

--- a/frontend/src/lib/components/QRCodeModal.svelte
+++ b/frontend/src/lib/components/QRCodeModal.svelte
@@ -3,6 +3,7 @@
     PUBLIC_VITE_API_BASE_URL,
     PUBLIC_VITE_SHORT_LINK_BASE_URL
   } from "$env/static/public";
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { orgsApi } from "$lib/api/orgs";
   import type { Link } from "$lib/types/api";
   import QRCodeStyling from "qr-code-styling";
@@ -210,19 +211,18 @@
 <svelte:window onkeydown={handleKeydown} />
 
 {#if isOpen && link}
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
     class="fixed inset-0 z-50 overflow-y-auto"
     aria-labelledby="qr-modal-title"
     role="dialog"
     aria-modal="true"
     tabindex="-1"
-    onclick={(e) => {
-      if (e.target === e.currentTarget) onClose();
-    }}
   >
     <!-- Backdrop -->
-    <div class="fixed inset-0 bg-gray-900/50 transition-opacity"></div>
+    <div
+      class="fixed inset-0 bg-gray-900/50 transition-opacity"
+      use:backdropClose={onClose}
+    ></div>
 
     <div class="flex min-h-full items-center justify-center p-4">
       <div

--- a/frontend/src/lib/components/ReportDialog.svelte
+++ b/frontend/src/lib/components/ReportDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { adminApi } from "$lib/api/admin";
 
   interface Props {
@@ -54,13 +55,7 @@
 </script>
 
 {#if !submitted}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={onClose}
-    onkeydown={(e) => e.key === "Enter" && onClose()}
-  >
+  <div class="modal-backdrop" use:backdropClose={onClose}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -128,13 +123,7 @@
     </div>
   </div>
 {:else}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={onClose}
-    onkeydown={(e) => e.key === "Enter" && onClose()}
-  >
+  <div class="modal-backdrop" use:backdropClose={onClose}>
     <div
       class="modal success-modal"
       onclick={(e) => e.stopPropagation()}

--- a/frontend/src/routes/admin/billing/+page.svelte
+++ b/frontend/src/routes/admin/billing/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { adminApi } from "$lib/api/admin";
   import Pagination from "$lib/components/Pagination.svelte";
   import type {
@@ -703,13 +704,7 @@
 
 <!-- Force Transfer Modal -->
 {#if confirmingForceTransfer}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={cancelForceTransfer}
-    onkeydown={(e) => e.key === "Enter" && cancelForceTransfer()}
-  >
+  <div class="modal-backdrop" use:backdropClose={cancelForceTransfer}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -784,13 +779,7 @@
 
 <!-- Tier Change Modal -->
 {#if confirmingTierChange}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={cancelTierChange}
-    onkeydown={(e) => e.key === "Enter" && cancelTierChange()}
-  >
+  <div class="modal-backdrop" use:backdropClose={cancelTierChange}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -841,13 +830,7 @@
 
 <!-- Reset Counter Modal -->
 {#if confirmingReset}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={cancelReset}
-    onkeydown={(e) => e.key === "Enter" && cancelReset()}
-  >
+  <div class="modal-backdrop" use:backdropClose={cancelReset}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -896,13 +879,7 @@
 
 <!-- Subscription Update Modal -->
 {#if confirmingSubscriptionUpdate}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={cancelSubscriptionUpdate}
-    onkeydown={(e) => e.key === "Escape" && cancelSubscriptionUpdate()}
-  >
+  <div class="modal-backdrop" use:backdropClose={cancelSubscriptionUpdate}>
     <div
       class="modal"
       role="dialog"

--- a/frontend/src/routes/admin/blacklist/+page.svelte
+++ b/frontend/src/routes/admin/blacklist/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { adminApi } from "$lib/api/admin";
   import type { BlacklistEntry } from "$lib/types/api";
   import { onMount } from "svelte";
@@ -204,13 +205,7 @@
 
 <!-- Add Entry Modal -->
 {#if showAddModal}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={() => (showAddModal = false)}
-    onkeydown={(e) => e.key === "Enter" && (showAddModal = false)}
-  >
+  <div class="modal-backdrop" use:backdropClose={() => (showAddModal = false)}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -285,10 +280,7 @@
 {#if showRemoveModal && selectedEntry}
   <div
     class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={() => (showRemoveModal = false)}
-    onkeydown={(e) => e.key === "Enter" && (showRemoveModal = false)}
+    use:backdropClose={() => (showRemoveModal = false)}
   >
     <div
       class="modal"

--- a/frontend/src/routes/admin/links/+page.svelte
+++ b/frontend/src/routes/admin/links/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { adminApi } from "$lib/api/admin";
   import Pagination from "$lib/components/Pagination.svelte";
   import type { AdminLink, ApiError } from "$lib/types/api";
@@ -559,13 +560,7 @@
 
 <!-- Delete Confirmation Modal -->
 {#if confirmingAction === "delete"}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={closeConfirm}
-    onkeydown={(e) => e.key === "Enter" && closeConfirm()}
-  >
+  <div class="modal-backdrop" use:backdropClose={closeConfirm}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -601,13 +596,7 @@
 
 <!-- Block Destination Modal -->
 {#if confirmingAction === "block"}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={closeConfirm}
-    onkeydown={(e) => e.key === "Enter" && closeConfirm()}
-  >
+  <div class="modal-backdrop" use:backdropClose={closeConfirm}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -680,13 +669,7 @@
 
 <!-- Click outside to close dropdown -->
 {#if activeDropdown}
-  <div
-    class="dropdown-overlay"
-    role="button"
-    tabindex="0"
-    onclick={closeDropdown}
-    onkeydown={(e) => e.key === "Enter" && closeDropdown()}
-  ></div>
+  <div class="dropdown-overlay" use:backdropClose={closeDropdown}></div>
 {/if}
 
 <style>

--- a/frontend/src/routes/admin/reports/+page.svelte
+++ b/frontend/src/routes/admin/reports/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { adminApi } from "$lib/api/admin";
   import { authApi } from "$lib/api/auth";
   import type {
@@ -539,13 +540,7 @@
 
 <!-- Block URL Modal -->
 {#if showBlockUrlModal && selectedReport}
-  <div
-    class="modal-overlay"
-    role="button"
-    tabindex="0"
-    onclick={closeModal}
-    onkeydown={(e) => e.key === "Enter" && closeModal()}
-  >
+  <div class="modal-overlay" use:backdropClose={closeModal}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -578,13 +573,7 @@
 
 <!-- Block Domain Modal -->
 {#if showBlockDomainModal && selectedReport}
-  <div
-    class="modal-overlay"
-    role="button"
-    tabindex="0"
-    onclick={closeModal}
-    onkeydown={(e) => e.key === "Enter" && closeModal()}
-  >
+  <div class="modal-overlay" use:backdropClose={closeModal}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -619,13 +608,7 @@
 
 <!-- Disable Link Modal -->
 {#if showDisableModal && selectedReport}
-  <div
-    class="modal-overlay"
-    role="button"
-    tabindex="0"
-    onclick={closeModal}
-    onkeydown={(e) => e.key === "Enter" && closeModal()}
-  >
+  <div class="modal-overlay" use:backdropClose={closeModal}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -660,13 +643,7 @@
 
 <!-- Dismiss Modal -->
 {#if showDismissModal && selectedReport}
-  <div
-    class="modal-overlay"
-    role="button"
-    tabindex="0"
-    onclick={closeModal}
-    onkeydown={(e) => e.key === "Enter" && closeModal()}
-  >
+  <div class="modal-overlay" use:backdropClose={closeModal}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}

--- a/frontend/src/routes/admin/settings/+page.svelte
+++ b/frontend/src/routes/admin/settings/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { adminApi, type Discount, type Product } from "$lib/api/admin";
   import { billingApi, type ProductPrice } from "$lib/api/billing";
   import {
@@ -989,10 +990,7 @@
   {#if confirmingSignupToggle}
     <div
       class="modal-backdrop"
-      role="button"
-      tabindex="0"
-      onclick={() => (confirmingSignupToggle = false)}
-      onkeydown={(e) => e.key === "Enter" && (confirmingSignupToggle = false)}
+      use:backdropClose={() => (confirmingSignupToggle = false)}
     >
       <div
         class="modal"
@@ -1053,11 +1051,7 @@
   {#if confirmingFounderPricingToggle}
     <div
       class="modal-backdrop"
-      role="button"
-      tabindex="0"
-      onclick={() => (confirmingFounderPricingToggle = false)}
-      onkeydown={(e) =>
-        e.key === "Enter" && (confirmingFounderPricingToggle = false)}
+      use:backdropClose={() => (confirmingFounderPricingToggle = false)}
     >
       <div
         class="modal"

--- a/frontend/src/routes/admin/users/+page.svelte
+++ b/frontend/src/routes/admin/users/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { adminApi } from "$lib/api/admin";
   import { authApi } from "$lib/api/auth";
   import Avatar from "$lib/components/Avatar.svelte";
@@ -535,13 +536,7 @@
 
 <!-- Role Change Confirmation Modal -->
 {#if confirmingUserId && confirmingRole}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={cancelRoleChange}
-    onkeydown={(e) => e.key === "Enter" && cancelRoleChange()}
-  >
+  <div class="modal-backdrop" use:backdropClose={cancelRoleChange}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -597,13 +592,7 @@
 
 <!-- Suspend Confirmation Modal -->
 {#if confirmingSuspend}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={cancelSuspend}
-    onkeydown={(e) => e.key === "Enter" && cancelSuspend()}
-  >
+  <div class="modal-backdrop" use:backdropClose={cancelSuspend}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -648,13 +637,7 @@
 
 <!-- Delete Confirmation Modal -->
 {#if confirmingDelete}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={cancelDelete}
-    onkeydown={(e) => e.key === "Enter" && cancelDelete()}
-  >
+  <div class="modal-backdrop" use:backdropClose={cancelDelete}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}
@@ -709,13 +692,7 @@
 
 <!-- Click outside to close dropdown -->
 {#if activeDropdown}
-  <div
-    class="dropdown-overlay"
-    role="button"
-    tabindex="0"
-    onclick={closeDropdown}
-    onkeydown={(e) => e.key === "Enter" && closeDropdown()}
-  ></div>
+  <div class="dropdown-overlay" use:backdropClose={closeDropdown}></div>
 {/if}
 
 <style>

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto, invalidate } from "$app/navigation";
+  import { backdropClose } from "$lib/actions/backdropClose";
   import type { CustomDomain } from "$lib/api/domains";
   import { domainsApi } from "$lib/api/domains";
   import { linksApi, tagsApi } from "$lib/api/links";
@@ -9,6 +10,7 @@
   import Pagination from "$lib/components/Pagination.svelte";
   import QRCodeModal from "$lib/components/QRCodeModal.svelte";
   import SearchFilterBar from "$lib/components/SearchFilterBar.svelte";
+  import { DEFAULT_MIN_CUSTOM_CODE_LENGTH } from "$lib/constants";
   import type {
     ApiError,
     Link,
@@ -17,7 +19,6 @@
     UsageResponse,
     User
   } from "$lib/types/api";
-  import { DEFAULT_MIN_CUSTOM_CODE_LENGTH } from "$lib/constants";
   import { onDestroy, onMount } from "svelte";
   import { SvelteURLSearchParams } from "svelte/reactivity";
 
@@ -466,12 +467,11 @@
 
             {#if isActionsMenuOpen}
               <!-- Click-outside overlay -->
-              <button
+              <div
                 class="fixed inset-0 z-10 cursor-default bg-transparent border-0 p-0"
-                onclick={() => (isActionsMenuOpen = false)}
+                use:backdropClose={() => (isActionsMenuOpen = false)}
                 aria-label="Close menu"
-                tabindex="-1"
-              ></button>
+              ></div>
               <div
                 class="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-xl shadow-lg z-20 overflow-hidden"
               >

--- a/frontend/src/routes/dashboard/org/+page.svelte
+++ b/frontend/src/routes/dashboard/org/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { backdropClose } from "$lib/actions/backdropClose";
   import type { BillingStatus } from "$lib/api/billing";
   import { billingApi } from "$lib/api/billing";
   import { resolveLogoUrl } from "$lib/api/client";
@@ -2502,18 +2503,7 @@
 
 <!-- Remove Member Confirmation Modal -->
 {#if confirmingRemoveMember}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={cancelRemoveMember}
-    onkeydown={(e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        cancelRemoveMember();
-      }
-    }}
-  >
+  <div class="modal-backdrop" use:backdropClose={cancelRemoveMember}>
     <div class="modal" role="dialog" aria-modal="true" tabindex="-1">
       <div class="modal-header">
         <h3>Remove Member?</h3>
@@ -2542,13 +2532,7 @@
 
 <!-- Domain Deletion Confirmation Modal -->
 {#if confirmingDomainHostname}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={closeConfirmDomain}
-    onkeydown={(e) => e.key === "Enter" && closeConfirmDomain()}
-  >
+  <div class="modal-backdrop" use:backdropClose={closeConfirmDomain}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}

--- a/frontend/src/routes/report/+page.svelte
+++ b/frontend/src/routes/report/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
+  import { backdropClose } from "$lib/actions/backdropClose";
   import { authApi } from "$lib/api/auth";
   import { apiClient } from "$lib/api/client";
   import LoadingButton from "$lib/components/LoadingButton.svelte";
@@ -277,13 +278,7 @@
 
 <!-- Report Dialog -->
 {#if showReportDialog}
-  <div
-    class="modal-backdrop"
-    role="button"
-    tabindex="0"
-    onclick={closeDialog}
-    onkeydown={(e) => e.key === "Enter" && closeDialog()}
-  >
+  <div class="modal-backdrop" use:backdropClose={closeDialog}>
     <div
       class="modal"
       onclick={(e) => e.stopPropagation()}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { backdropClose } from "$lib/actions/backdropClose";
   import type { BillingStatus } from "$lib/api/billing";
   import { billingApi } from "$lib/api/billing";
   import { apiClient } from "$lib/api/client";
@@ -825,10 +826,7 @@
 {#if keyToDelete}
   <div
     class="fixed inset-0 bg-gray-900/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
-    role="button"
-    tabindex="0"
-    onclick={() => (keyToDelete = null)}
-    onkeydown={(e) => e.key === "Escape" && (keyToDelete = null)}
+    use:backdropClose={() => (keyToDelete = null)}
   >
     <div
       class="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6"
@@ -919,10 +917,7 @@
 {#if editScopeKey}
   <div
     class="fixed inset-0 bg-gray-900/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
-    role="button"
-    tabindex="0"
-    onclick={() => (editScopeKey = null)}
-    onkeydown={(e) => e.key === "Escape" && (editScopeKey = null)}
+    use:backdropClose={() => (editScopeKey = null)}
   >
     <div
       class="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6"


### PR DESCRIPTION
Replace onclick backdrop handlers with a pointer-event Svelte action so drag-initiated mouseups outside the modal no longer close it.

Fixes #457 